### PR TITLE
feat(17): 카카오맵 api 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3603,7 +3603,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -3880,7 +3880,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -4248,7 +4248,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-declaration-sorter": {
       "version": "6.2.2",

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko">
 
 <head>
   <meta charset="utf-8" />
@@ -17,22 +17,17 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800&family=Noto+Sans:wght@300;400;500;600;700;800&display=swap"
     rel="stylesheet">
+
+  <!-- kakao map -->
+  <script type="text/javascript" src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+  <script src="//dapi.kakao.com/v2/maps/sdk.js?appkey=aa90b5cd8734fb0ed66e4f3aab95a147&autoload=false&libraries=services"></script>
+
   <title>React App</title>
 </head>
 
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
 </body>
 
 </html>

--- a/src/components/Location/Map.tsx
+++ b/src/components/Location/Map.tsx
@@ -1,12 +1,60 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { StyledMap } from "../../styles/locationStyle";
+import { DetailType } from "../../types";
 
-function Map() {
-    return (
-        <StyledMap>
-            TBD
-        </StyledMap>
-    )
+function Map({ address }: Partial<DetailType>) {
+
+  const { kakao } = (window as any);
+
+  const container = useRef<HTMLDivElement>(null);
+
+  const onLoadKakaoMap = () => {
+    kakao.maps.load(() => {
+      const mapOption = {
+        center: new kakao.maps.LatLng(127.044754852849, 37.5491962171866), // 지도의 중심좌표
+        level: 2 // 지도의 확대 레벨
+      };
+
+      // 지도를 생성합니다
+      const map = new kakao.maps.Map(container.current, mapOption);
+
+      // 주소-좌표 변환 객체를 생성합니다
+      const geocoder = new kakao.maps.services.Geocoder();
+
+      // 주소로 좌표를 검색합니다
+      geocoder.addressSearch(address, (result: any, status: any) => {
+        // 정상적으로 검색이 완료됐으면
+        if (status === kakao.maps.services.Status.OK) {
+          const coords = new kakao.maps.LatLng(result[0].y, result[0].x);
+
+          // 결과값으로 받은 위치를 마커로 표시합니다
+          const marker = new kakao.maps.Marker({
+            map,
+            position: coords
+          });
+
+          // 지도의 중심을 결과값으로 받은 위치로 이동시킵니다
+          map.setCenter(coords);
+        } else {
+          console.log(result, status);
+        }
+      });
+    });
+  };
+
+  useEffect(() => {
+    if (kakao) {
+      if (kakao.maps) {
+        onLoadKakaoMap(); // 첫 로딩 시
+      } else {
+        kakao.addEventListener("load", onLoadKakaoMap); // 새로고침 시
+      }
+    }
+  }, [kakao]);
+
+  return (
+    <StyledMap ref={container} />
+  );
 }
 
 export default Map;

--- a/src/components/Location/index.tsx
+++ b/src/components/Location/index.tsx
@@ -4,13 +4,13 @@ import { DetailType } from "../../types";
 import Map from "./Map";
 
 function Location({ address }: Partial<DetailType>) {
-	return (
-		<StyledLocation>
-			<h4>위치</h4>
-			<Map />
-			<p>{address}</p>
-		</StyledLocation>
-	);
+  return (
+    <StyledLocation>
+      <h4>위치</h4>
+      <Map address={address} />
+      <p>{address}</p>
+    </StyledLocation>
+  );
 }
 
 export default Location;


### PR DESCRIPTION
## 구현 내용 
- 상세페이지에 사용되는 Map.tsx 컴포넌트에 카카오맵 api 연동
  
## 참고 사항 
- index.html에 카카오 sdk 추가하였습니다
- 브라우저 자동 번역 팝업 없애기 위해 `<html lang="ko">`로 바꿨습니다
   