### PR TITLE
fix(31): 특전 목록 스타일 수정, 계정명에 @ 추가, 해시태그 수정

### DIFF
--- a/src/components/EventList/EventListItem.tsx
+++ b/src/components/EventList/EventListItem.tsx
@@ -25,7 +25,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
 			</div>
 			<p>
 				<BiUserCircle />
-				{organizer} {snsId}
+				{organizer} @{snsId}
 			</p>
 			<p>
 				<BiMap />

--- a/src/components/EventMain/index.tsx
+++ b/src/components/EventMain/index.tsx
@@ -23,7 +23,7 @@ const EventMain = ({ place, bias, organizer, snsId, startAt, endAt, address, ima
         </div>
         <p>
           <BiUserCircle />
-          {organizer} {snsId}
+          {organizer} @{snsId}
         </p>
         <p>
           <BiMap />

--- a/src/components/TwitterInfo/index.tsx
+++ b/src/components/TwitterInfo/index.tsx
@@ -6,21 +6,21 @@ import { DetailType, EventType } from "../../types";
 type TwitterInfoProps = Partial<EventType> & Partial<DetailType>;
 
 function TwitterInfo({ organizer, snsId, hashTags }: TwitterInfoProps) {
-	return (
-		<StyledTwitterInfo>
-			<div className="account">
-				<h6>{organizer}</h6>
-				<p>
-					<FaTwitter />@{snsId}
-				</p>
-			</div>
-			<div className="hashTags">
-				{hashTags?.map((tag) => (
-					<p key={tag}>#{tag}</p>
-				))}
-			</div>
-		</StyledTwitterInfo>
-	);
+  return (
+    <StyledTwitterInfo>
+      <div className="account">
+        <h6>{organizer}</h6>
+        <p>
+          <FaTwitter />@{snsId}
+        </p>
+      </div>
+      <div className="hashTags">
+        {hashTags?.map((tag) =>
+          tag === "" ? null : <p key={tag}>#{tag}</p>
+        )}
+      </div>
+    </StyledTwitterInfo>
+  );
 }
 
 export default TwitterInfo;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -6,7 +6,7 @@ import { StyledMain } from "../styles/mainStyle";
 
 function Main() {
 	return (
-		<Layout>
+		<Layout dateSelector>
 			<StyledMain>
 				<Filter />
 				<EventList />

--- a/src/styles/goodsInfoStyle.ts
+++ b/src/styles/goodsInfoStyle.ts
@@ -60,14 +60,22 @@ const StyledGoodsListItem = styled.div<{ type: "AND" | "OR" }>`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	gap: 10px;
-	height: 100px;
+	margin: 16px 0;
+	
+	h6 {
+		margin-bottom: 16px;
+	}
 
 	ul {
 		display: flex;
 		align-items: center;
-		height: 40px;
+		flex-wrap: wrap;
 
+		> li {
+			height: 30px;
+			margin-bottom: 8px;
+		}
+		
 		> li:not(:last-child):after {
 			${(props) =>
 				props.type === "AND"


### PR DESCRIPTION
## 구현 내용 
- 특전 길이가 긴 경우 화면 깨짐 수정
- 트위터 계정명 앞에 `@` 추가
- 이벤트에 해시태그 없는 경우 표시되지 않도록 수정
  
## 참고 사항 
- 메인 페이지 헤더에 `DateSelector` 컴포넌트 표시해뒀습니다
   
## 연관 이슈
