### PR TITLE
feat(33): 가까운 연관 이벤트 구현

### DIFF
--- a/src/components/EventList/EventListItem.tsx
+++ b/src/components/EventList/EventListItem.tsx
@@ -25,7 +25,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
 			</div>
 			<p>
 				<BiUserCircle />
-				{organizer} {snsId}
+				{organizer} @{snsId}
 			</p>
 			<p>
 				<BiMap />

--- a/src/components/EventMain/index.tsx
+++ b/src/components/EventMain/index.tsx
@@ -23,7 +23,7 @@ const EventMain = ({ place, bias, organizer, snsId, startAt, endAt, address, ima
         </div>
         <p>
           <BiUserCircle />
-          {organizer} {snsId}
+          {organizer} @{snsId}
         </p>
         <p>
           <BiMap />

--- a/src/components/EventsNearHere/EventNearHereLIst.tsx
+++ b/src/components/EventsNearHere/EventNearHereLIst.tsx
@@ -1,17 +1,22 @@
 import React from "react";
-import {StyledEventNearHereList} from "../../styles/eventNearHereStyle";
+import { useNavigate } from "react-router-dom";
+import { StyledEventNearHereList } from "../../styles/eventNearHereStyle";
+import { EventType } from "../../types";
 
+function EventNearHereList({ id, images, place, organizer }: Partial<EventType>) {
 
-function EventNearHereList() {
-    return (
-        <StyledEventNearHereList>
-            <img alt="sample" src="https://pbs.twimg.com/media/FWgAyjfaIAEHkKO?format=jpg&name=4096x4096"/>
-            <div>
-                <h6>열글자 넘는 카페이름</h6>
-                <p>호시 by TILL THE TOP</p>
-            </div>
-        </StyledEventNearHereList>
-    )
+  const navigate = useNavigate();
+  const previewUrl = (images && images[0]) || "";
+
+  return (
+    <StyledEventNearHereList onClick={() => navigate(`/detail/${id}`)}>
+      {previewUrl && <img alt={previewUrl} src={previewUrl} />}
+      <div>
+        <h6>{place}</h6>
+        <p>{organizer}</p>
+      </div>
+    </StyledEventNearHereList>
+  );
 }
 
 export default EventNearHereList;

--- a/src/components/EventsNearHere/index.tsx
+++ b/src/components/EventsNearHere/index.tsx
@@ -1,20 +1,40 @@
 import React from "react";
-import {StyledEventNearHere} from "../../styles/eventNearHereStyle";
+import { useQuery } from "react-query";
+import { useParams } from "react-router-dom";
+import { StyledEventNearHere } from "../../styles/eventNearHereStyle";
 import EventNearHereList from "./EventNearHereLIst";
+import { getEvents } from "../../apis";
+import { EventType } from "../../types";
 
-function EventNearHere() {
-    return (
-        <StyledEventNearHere>
-            <h4>가까운 연관 이벤트</h4>
-            <ul>
-                <EventNearHereList/>
-                <EventNearHereList/>
-                <EventNearHereList/>
-                <EventNearHereList/>
-                <EventNearHereList/>
-            </ul>
-        </StyledEventNearHere>
-    )
+function EventNearHere({ bias, district }: Partial<EventType>) {
+  const { id } = useParams();
+
+  const { data: nearEvent } = useQuery(["event", id], getEvents, {
+    enabled: !!id,
+    select: (data) => data?.filter((item) => {
+      if (bias && bias[0]) {
+        return item.id !== id && item.district === district && item.bias[0] === bias[0];
+      }
+      return null;
+    })
+  });
+
+  if (!nearEvent || nearEvent.length === 0) {
+    return null;
+  }
+
+  return (
+    <StyledEventNearHere>
+      <h4>가까운 연관 이벤트</h4>
+      <ul>
+        {nearEvent && nearEvent.map(event =>
+          <EventNearHereList id={event.id} key={event.id}
+                             images={event.images}
+                             place={event.place}
+                             organizer={event.organizer} />)}
+      </ul>
+    </StyledEventNearHere>
+  );
 }
 
 export default EventNearHere;

--- a/src/components/TwitterInfo/index.tsx
+++ b/src/components/TwitterInfo/index.tsx
@@ -6,21 +6,21 @@ import { DetailType, EventType } from "../../types";
 type TwitterInfoProps = Partial<EventType> & Partial<DetailType>;
 
 function TwitterInfo({ organizer, snsId, hashTags }: TwitterInfoProps) {
-	return (
-		<StyledTwitterInfo>
-			<div className="account">
-				<h6>{organizer}</h6>
-				<p>
-					<FaTwitter />@{snsId}
-				</p>
-			</div>
-			<div className="hashTags">
-				{hashTags?.map((tag) => (
-					<p key={tag}>#{tag}</p>
-				))}
-			</div>
-		</StyledTwitterInfo>
-	);
+  return (
+    <StyledTwitterInfo>
+      <div className="account">
+        <h6>{organizer}</h6>
+        <p>
+          <FaTwitter />@{snsId}
+        </p>
+      </div>
+      <div className="hashTags">
+        {hashTags?.map((tag) =>
+          tag === "" ? null : <p key={tag}>#{tag}</p>
+        )}
+      </div>
+    </StyledTwitterInfo>
+  );
 }
 
 export default TwitterInfo;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -91,6 +91,9 @@ function Admin() {
       address: ""
     });
     setGoods([]);
+
+    alert("등록되었습니다!");
+    window.scrollTo(0, 0);
   };
 
   return (
@@ -135,6 +138,7 @@ function Admin() {
 
           <label htmlFor="district">
             <h4 className="required">카페 지역</h4>
+            <span className="help">⚠️ ❍❍시 ❍❍구로 입력해주세요(특별시, 광역시 등등 제외)</span>
             <input type="text" id="district" name="district"
                    placeholder="예: 서울시 마포구"
                    value={events.district}
@@ -164,6 +168,14 @@ function Admin() {
                    placeholder="예: https://pbs.twimg.com/media/abc, https://pbs.twimg.com/media/def"
                    value={events.images}
                    onChange={handleChangeEvents} />
+          </label>
+
+          <label htmlFor="address">
+            <h4 className="required">상세주소</h4>
+            <input type="text" id="address" name="address"
+                   placeholder="예: 서울시 마포구 동교로9길 36 1층"
+                   value={detail.address}
+                   onChange={handleChangeDetail} />
           </label>
 
           <label htmlFor="hashTags">
@@ -209,19 +221,12 @@ function Admin() {
                 특전 목록:
                 <span className="help">⚠️ 여러개 입력 가능, 한개 이상인 경우 &quot;, &quot;(쉼표 후 띄어쓰기)로 구분해주세요</span>
                 <input type="text" id="items" name="items"
+                       placeholder="예: 컵홀더, 포토카드"
                        value={item.items}
                        onChange={(e) => setItem({ ...item, items: e.target.value })} />
               </label>
               <button className="goodsSubmitBtn" type="button" onClick={handleSubmitGoods}>특전등록 ✓</button>
             </div>
-          </label>
-
-          <label htmlFor="address">
-            <h4 className="required">상세주소</h4>
-            <input type="text" id="address" name="address"
-                   placeholder="예: 서울시 마포구 동교로9길 36 1층"
-                   value={detail.address}
-                   onChange={handleChangeDetail} />
           </label>
 
           <button className="submitBtn" type="submit" onClick={handleSubmit}>등록</button>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -26,7 +26,7 @@ const Detail = () => {
 
 	if (!event || !detail) return null;
 
-	const { place, bias, organizer, snsId, startAt, endAt, images } = event;
+	const { place, bias, organizer, snsId, startAt, endAt, images, district } = event;
 	const { address, goods, hashTags } = detail;
 
 	return (
@@ -45,7 +45,7 @@ const Detail = () => {
 				<TwitterInfo organizer={organizer} snsId={snsId} hashTags={hashTags} />
 				<GoodsInfo goods={goods} />
 				<Location address={address} />
-				<EventNearHere />
+				<EventNearHere bias={bias} district={district}/>
 			</StyledDetail>
 		</Layout>
 	);

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -6,7 +6,7 @@ import { StyledMain } from "../styles/mainStyle";
 
 function Main() {
 	return (
-		<Layout>
+		<Layout dateSelector>
 			<StyledMain>
 				<Filter />
 				<EventList />

--- a/src/styles/eventNearHereStyle.ts
+++ b/src/styles/eventNearHereStyle.ts
@@ -35,6 +35,7 @@ const StyledEventNearHereList = styled.li`
   display: inline-block;
   min-width: 120px;
   width: 120px;
+  cursor: pointer;
 
   &:first-child {
     margin-left: 20px;

--- a/src/styles/goodsInfoStyle.ts
+++ b/src/styles/goodsInfoStyle.ts
@@ -60,14 +60,22 @@ const StyledGoodsListItem = styled.div<{ type: "AND" | "OR" }>`
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	gap: 10px;
-	height: 100px;
+	margin: 16px 0;
+	
+	h6 {
+		margin-bottom: 16px;
+	}
 
 	ul {
 		display: flex;
 		align-items: center;
-		height: 40px;
+		flex-wrap: wrap;
 
+		> li {
+			height: 30px;
+			margin-bottom: 8px;
+		}
+		
 		> li:not(:last-child):after {
 			${(props) =>
 				props.type === "AND"


### PR DESCRIPTION
## 구현 내용 
- 가까운 연관 이벤트 기능 구현
- 지역(ㅇㅇ시 ㅇㅇ구)와 아티스트 이름이 같은 경우로 필터링하였습니다
  
## 참고 사항 
- 연관 이벤트가 없는 경우 상세페이지에 해당 컴포넌트 보이지 않도록 하였습니다
- 어드민 페이지에 이벤트 등록 완료 시 스크롤 상단으로 올라가도록 개선하였습니다
   
## 연관 이슈
