### PR TITLE
feat(20): 인물 테이블 생성 및 연동, recoil 전역 state 작성, 월별 생일 프로필 표시 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1920,6 +1920,27 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
       "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
     },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/gen-mapping": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+          "requires": {
+            "@jridgewell/set-array": "^1.0.1",
+            "@jridgewell/sourcemap-codec": "^1.4.10",
+            "@jridgewell/trace-mapping": "^0.3.9"
+          }
+        }
+      }
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
@@ -3663,7 +3684,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "babel-plugin-transform-react-remove-prop-types": {
       "version": "0.4.24",
@@ -3945,7 +3966,7 @@
     "camelize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "integrity": "sha512-W2lPwkBkMZwFlPCXhIlYgxu+7gC/NUlCtdK652DAJ1JdgV0sTrvuPFshNPrFa1TY2JOkLhgdeEBplB4ezEa+xg=="
+      "integrity": "sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs="
     },
     "caniuse-api": {
       "version": "3.0.0",
@@ -4318,7 +4339,7 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+      "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-declaration-sorter": {
       "version": "6.2.2",
@@ -11508,13 +11529,13 @@
       }
     },
     "terser": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.13.1.tgz",
-      "integrity": "sha512-hn4WKOfwnwbYfe48NgrQjqNOH9jzLqRcIfbYytOXCOv46LBfWr9bDS17MQqOi+BWGD0sJK3Sj5NC/gJjiojaoA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.8.0-beta.0",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -11522,14 +11543,6 @@
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-        },
-        "source-map": {
-          "version": "0.8.0-beta.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
-          "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
-          "requires": {
-            "whatwg-url": "^7.0.0"
-          }
         }
       }
     },

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -22,6 +22,14 @@ const fetchDetail = async ({ id }: { id?: string }) => {
 	return data?.[0];
 };
 
+const fetchPeople = async () => {
+	const { data, error } = await supabase.from("people").select("*");
+	if (error) {
+		throw new Error(`${error.message}: ${error.details}`);
+	}
+	return data;
+};
+
 const insertEvent = async (eventData: Partial<EventType>) => {
 	const { data, error } = await supabase.from("events").insert([{ ...eventData }]);
 
@@ -40,5 +48,5 @@ const insertDetail = async (detailData: Partial<DetailType>) => {
 	return data;
 };
 
-export { fetchEvents, fetchDetail, insertEvent, insertDetail };
+export { fetchEvents, fetchDetail, fetchPeople, insertEvent, insertDetail };
 export default {};

--- a/src/components/Filter/Bias.tsx
+++ b/src/components/Filter/Bias.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import { StyledBias } from "../../styles/filterStyle";
+import { PeopleType } from "../../types";
 
-function Bias() {
+function Bias({ name, profilePic }: Partial<PeopleType>) {
 
-    return (
-        <StyledBias>
-            <div>
-                <img alt="sample"
-                    src="https://www.pledis.co.kr/_data/file/bbsData/9bd8e1181d215f7422e1c53d7004b2bb.jpg" />
-            </div>
-            <p>호시</p>
-        </StyledBias>
-    )
+  return (
+    <StyledBias>
+      <div>
+        <img alt={profilePic} src={profilePic} />
+      </div>
+      <p>{name}</p>
+    </StyledBias>
+  );
 }
 
 export default Bias;

--- a/src/components/Filter/Bias.tsx
+++ b/src/components/Filter/Bias.tsx
@@ -1,11 +1,23 @@
 import React from "react";
+import { useRecoilState } from "recoil";
+import { biasState } from "../../state/atoms";
 import { StyledBias } from "../../styles/filterStyle";
 import { PeopleType } from "../../types";
 
 function Bias({ name, profilePic }: Partial<PeopleType>) {
 
+  const [bias, setBias] = useRecoilState(biasState);
+
+  const handleClickBias = (n: string) => {
+    setBias(n);
+  };
+
+  if (!name) {
+    return null;
+  }
   return (
-    <StyledBias>
+    <StyledBias onClick={() => handleClickBias(name)}
+                className={bias === "" || bias === name ? "active" : ""}>
       <div>
         <img alt={profilePic} src={profilePic} />
       </div>

--- a/src/components/Filter/BiasList.tsx
+++ b/src/components/Filter/BiasList.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import { useQuery } from "react-query";
+import { useRecoilState } from "recoil";
+import { monthState } from "../../state/atoms";
 import { fetchPeople } from "../../apis";
 import { StyledBiasList } from "../../styles/filterStyle";
 import Bias from "./Bias";
 
 function BiasList() {
-
-  const filteredMonth = "08"; // todo: DateSelector 컴포넌트와 연결
+  const [month] = useRecoilState(monthState);
 
   const { data: people } = useQuery(["people"], () => fetchPeople(), {
-    select: (data) => data?.filter((item) => item.birthday.slice(4, 6) === filteredMonth)
+    select: (data) => data?.filter((item) => item.birthday.slice(4, 6) === month)
   });
 
   return (

--- a/src/components/Filter/BiasList.tsx
+++ b/src/components/Filter/BiasList.tsx
@@ -1,20 +1,25 @@
 import React from "react";
+import { useQuery } from "react-query";
+import { fetchPeople } from "../../apis";
 import { StyledBiasList } from "../../styles/filterStyle";
 import Bias from "./Bias";
 
 function BiasList() {
 
-    return (
-        <StyledBiasList>
-            <Bias />
-            <Bias />
-            <Bias />
-            <Bias />
-            <Bias />
-            <Bias />
-            <Bias />
-        </StyledBiasList>
-    )
+  const filteredMonth = "08"; // todo: DateSelector 컴포넌트와 연결
+
+  const { data: people } = useQuery(["people"], () => fetchPeople(), {
+    select: (data) => data?.filter((item) => item.birthday.slice(4, 6) === filteredMonth)
+  });
+
+  return (
+    <StyledBiasList>
+      {people?.map((person) =>
+        <Bias key={person.id}
+              name={person.name}
+              profilePic={person.profilePic} />)}
+    </StyledBiasList>
+  );
 }
 
 export default BiasList;

--- a/src/components/header/DateSelector.tsx
+++ b/src/components/header/DateSelector.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useRecoilState } from "recoil";
+import { monthState } from "../../state/atoms";
 
-function DateSeletor() {
+function DateSelector() {
+  const [month, setMonth] = useRecoilState(monthState);
 
 	const today = new Date();
 
@@ -8,24 +11,21 @@ function DateSeletor() {
 
 	const year = selectedDate.getFullYear();
 
-	const getMonthString = (month: number): string => {
-		if (month < 10) {
-			return `0${month}`;
-		}
-		return `${month}`;
-	}
-	const month = getMonthString(selectedDate.getMonth() + 1);
-
-	function getPrevMonth() {
-		const prev = new Date(year, selectedDate.getMonth() - 1, 1)
-		setSelectedDate(prev)
-	}
+  function getPrevMonth() {
+    const prev = new Date(year, selectedDate.getMonth() - 1, 1);
+    setSelectedDate(prev);
+  }
 
 	function getNextMonth() {
 		const next = new Date(year, selectedDate.getMonth() + 1, 1)
 		setSelectedDate(next)
 	}
 
+  useEffect(() => {
+    const newMonth: number = selectedDate.getMonth() + 1;
+    const currentMonthString: string = newMonth < 10 ? `0${newMonth}` : `${newMonth}`;
+    setMonth(currentMonthString);
+  }, [selectedDate]);
 
 	return (
 		<div className="date_selector">
@@ -44,4 +44,4 @@ function DateSeletor() {
 	);
 }
 
-export default DateSeletor;
+export default DateSelector;

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,1 +1,18 @@
+import { atom } from "recoil";
+
+const today = new Date();
+const month: number = today.getMonth() + 1;
+const currentMonthString: string = month < 10 ? `0${month}` : `${month}`;
+
+const monthState = atom({
+  key: "monthState",
+  default: currentMonthString
+});
+
+const biasState = atom({
+  key: "biasState",
+  default: ""
+});
+
+export { monthState, biasState };
 export default {};

--- a/src/styles/filterStyle.ts
+++ b/src/styles/filterStyle.ts
@@ -40,6 +40,12 @@ const StyledBiasList = styled.ul`
 
 const StyledBias = styled.li`
 	margin: 0 12px;
+  opacity: 0.5;
+  cursor: pointer;
+  
+  &.active {
+    opacity: 1;
+  }
 
 	&:first-child {
 		margin-left: 20px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,11 @@ export type DetailType = {
 	goods: GoodsItemType[];
 	hashTags: string[];
 };
+
+export type PeopleType = {
+	id: string;
+	createdAt: string;
+	name: string;
+	birthday: string;
+	profilePic: string;
+};


### PR DESCRIPTION
## 구현 내용 
- supabase에 인물 테이블 `people` 생성
- recoil 전역 state 추가
  - `monthState`: 메인페이지 상단 DateSelector로 선택한 월
  - `biasState`: 메인페이지 상단 인물 프로필 클릭을 통해 선택한 연예인 이름
-  메인페이지 상단 인물 프로필 선택되지 않은 프로필은 `opacity: 0.5;` 적용하여 차이를 두었습니다 나중에 디자인 회의때 확인!!

## 참고 사항 
- 인물 선택에 따른 메인페이지 이벤트리스트 필터링은 아직 하지않은 상태입니다!!! 
   무한스크롤 버그부터 확인 후 적용하면 좋을 듯
   
## 연관 이슈
