### PR TITLE
feat(38): 특전 자세히보기 링크 추가

### DIFF
--- a/src/components/GoodsInfo/index.tsx
+++ b/src/components/GoodsInfo/index.tsx
@@ -3,17 +3,17 @@ import { StyledGoodsInfo } from "../../styles";
 import { DetailType } from "../../types";
 import GoodsListItem from "./GoodsListItem";
 
-function GoodsInfo({ goods }: Partial<DetailType>) {
-	return (
-		<StyledGoodsInfo>
-			<h4>특전</h4>
-			{goods?.map((item) => (
-				<GoodsListItem goodsListItem={item} key={item.title} />
-			))}
-			<p>수량 등 특전에 관한 자세한 사항은 포스터 내 공지를 확인하세요.</p>
-			<button type="button">특전 자세히 보기</button>
-		</StyledGoodsInfo>
-	);
+function GoodsInfo({ goods, tweetUrl }: Partial<DetailType>) {
+  return (
+    <StyledGoodsInfo>
+      <h4>특전</h4>
+      {goods?.map((item) => (
+        <GoodsListItem goodsListItem={item} key={item.title} />
+      ))}
+      <p>수량 등 특전에 관한 자세한 사항은 포스터 내 공지를 확인하세요.</p>
+      <button type="button" onClick={() => tweetUrl && window.open(tweetUrl)}>특전 자세히 보기</button>
+    </StyledGoodsInfo>
+  );
 }
 
 export default GoodsInfo;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -3,6 +3,8 @@ import Layout from "../components/layout";
 import { StyledAdmin } from "../styles/adminStyle";
 import { insertEvent, insertDetail } from "../apis";
 
+// todo: 추후 컴포넌트 분리
+
 function Admin() {
 
   const [events, setEvents] = useState({
@@ -19,8 +21,10 @@ function Admin() {
   const [detail, setDetail] = useState({
     hashTags: "", // 배열로 변환 후 전송
     // goods: "",
-    address: ""
+    address: "",
+    tweetUrl: ""
   });
+
   const [goods, setGoods] = useState([] as any[]);
   const [item, setItem] = useState({
     type: "AND",
@@ -55,7 +59,7 @@ function Admin() {
   };
 
   const handleSubmit = async () => {
-    if (!events.place || !events.bias || !events.district || !events.startAt || !events.endAt || !detail.address) {
+    if (!events.place || !events.bias || !events.district || !events.startAt || !events.endAt || !detail.address|| !detail.tweetUrl) {
       alert("필수값 채워주세요!");
       return;
     }
@@ -71,7 +75,8 @@ function Admin() {
         id: eventData[0].id,
         hashTags: detail.hashTags.split(", "),
         goods,
-        address: detail.address
+        address: detail.address,
+        tweetUrl: detail.tweetUrl
       });
     }
 
@@ -88,7 +93,8 @@ function Admin() {
     });
     setDetail({
       hashTags: "",
-      address: ""
+      address: "",
+      tweetUrl: ""
     });
     setGoods([]);
 
@@ -185,6 +191,14 @@ function Admin() {
             <input type="text" id="hashTags" name="hashTags"
                    placeholder="예: happy_o-cup_day, 8월을_축하해"
                    value={detail.hashTags}
+                   onChange={handleChangeDetail} />
+          </label>
+
+          <label htmlFor="tweetUrl">
+            <h4 className="required">트윗링크</h4>
+            <input type="text" id="tweetUrl" name="tweetUrl"
+                   placeholder="예: https://twitter.com/account/status/1234567890?s=20&t=abcdefg"
+                   value={detail.tweetUrl}
                    onChange={handleChangeDetail} />
           </label>
 

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -25,7 +25,7 @@ const Detail = () => {
 	if (!event || !detail) return null;
 
 	const { place, bias, organizer, snsId, startAt, endAt, images, district } = event;
-	const { address, goods, hashTags } = detail;
+	const { address, goods, hashTags, tweetUrl } = detail;
 
 	return (
 		<Layout>
@@ -41,7 +41,7 @@ const Detail = () => {
 					images={images}
 				/>
 				<TwitterInfo organizer={organizer} snsId={snsId} hashTags={hashTags} />
-				<GoodsInfo goods={goods} />
+				<GoodsInfo goods={goods} tweetUrl={tweetUrl}/>
 				<Location address={address} />
 				<EventNearHere bias={bias} district={district} />
 			</StyledDetail>

--- a/src/styles/goodsInfoStyle.ts
+++ b/src/styles/goodsInfoStyle.ts
@@ -28,6 +28,7 @@ const StyledGoodsInfo = styled.div`
 		font-size: 16px;
 		line-height: 22px;
 		padding: 10px 20px;
+		cursor: pointer;
 	}
 `;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,4 +22,5 @@ export type DetailType = {
 	address: string;
 	goods: GoodsItemType[];
 	hashTags: string[];
+	tweetUrl: string;
 };


### PR DESCRIPTION
## 구현 내용 
- supabase `detail` 테이블에 `tweetUrl` 컬럼 추가
- 어드민 페이지에 트윗 링크 입력 input 추가
- 상세페이지 `특전 자세히보기` 버튼 클릭 시 새창으로 열리도록 구현
  
## 참고 사항 
- 기존에 입력된 데이터들에도 트윗링크 추가하였습니다.
- 어드민에서 데이터 입력 시에 `tweetUrl` 필수값입니다.
   
## 연관 이슈
