### PR TITLE
fix(26): 무한 스크롤 중복 데이터 버그 수정

### DIFF
--- a/src/components/EventList/index.tsx
+++ b/src/components/EventList/index.tsx
@@ -8,14 +8,18 @@ import { ITEMS_PER_PAGE } from "../../shared/constants";
 
 const EventList = () => {
 	const { ref, inView } = useInView();
-	const { data, hasNextPage, fetchNextPage } = useInfiniteQuery("events", () => fetchEvents({ infinite: true }), {
-		getNextPageParam: (lastPage, pages) => {
-			if (lastPage && lastPage?.length < ITEMS_PER_PAGE) {
-				return null;
-			}
-			return pages.length + 1;
-		},
-	});
+	const { data, hasNextPage, fetchNextPage } = useInfiniteQuery(
+		"events",
+		({ pageParam }) => fetchEvents({ pageParam, infinite: true }),
+		{
+			getNextPageParam: (lastPage, pages) => {
+				if (lastPage && lastPage?.length < ITEMS_PER_PAGE) {
+					return null;
+				}
+				return pages.length + 1;
+			},
+		}
+	);
 
 	useEffect(() => {
 		if (inView && hasNextPage) {


### PR DESCRIPTION
## 구현 내용 
- 무한 스크롤 시 중복 데이터만 연속으로 들어오는 버그 수정
- fetch 함수 리팩토링 하면서 pageParam이 전달되지 않게 되어 발생한 문제 🤹🏼‍♂️ 

