### PR TITLE
fix(41): 상세페이지 데이터 fetch 버그 수정

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -14,14 +14,48 @@ const fetchEvents = async ({ pageParam = 1, infinite = false }: { pageParam?: nu
 	return data;
 };
 
-const fetchDetail = async ({ id }: { id?: string }) => {
-	const { data, error } = await supabase.from("detail").select("*").eq("id", id);
-	if (error) {
-		throw new Error(`${error.message}: ${error.details}`);
-	}
-	return data?.[0];
+/**
+ * 아이디가 일치하는 event 데이터 반환
+ * @param {string} id
+ * @returns {EventType}
+ */
+const fetchEvent = async ({ id }: { id?: string }) => {
+  const { data, error } = await supabase.from("events").select("*").eq("id", id);
+  if (error) {
+    throw new Error(`${error.message}: ${error.details}`);
+  }
+  return data?.[0];
 };
 
+/**
+ * 아이디가 일치하는 detail 데이터 반환
+ * @param {string} id
+ * @returns {DetailType}
+ */
+const fetchDetail = async ({ id }: { id?: string }) => {
+  const { data, error } = await supabase.from("detail").select("*").eq("id", id);
+  if (error) {
+    throw new Error(`${error.message}: ${error.details}`);
+  }
+  return data?.[0];
+};
+
+/**
+ * 아이디가 일치하는 { ...event, ...detail } 데이터 통합하여 반환
+ * @param {string} id
+ * @returns {EventType & DetailType}
+ */
+const fetchEventDetail = async ({ id }: { id?: string }) => {
+  const event = await fetchEvent({ id });
+  const detail = await fetchDetail({ id });
+
+  return { ...event, ...detail };
+};
+
+/**
+ * 인물 데이터 반환
+ * @returns {PeopleType}
+ */
 const fetchPeople = async () => {
 	const { data, error } = await supabase.from("people").select("*");
 	if (error) {
@@ -32,7 +66,6 @@ const fetchPeople = async () => {
 
 const insertEvent = async (eventData: Partial<EventType>) => {
 	const { data, error } = await supabase.from("events").insert([{ ...eventData }]);
-
 	if (error) {
 		throw new Error(`${error.message}: ${error.details}`);
 	}
@@ -41,12 +74,11 @@ const insertEvent = async (eventData: Partial<EventType>) => {
 
 const insertDetail = async (detailData: Partial<DetailType>) => {
 	const { data, error } = await supabase.from("detail").insert([{ ...detailData }]);
-
 	if (error) {
 		throw new Error(`${error.message}: ${error.details}`);
 	}
 	return data;
 };
 
-export { fetchEvents, fetchDetail, fetchPeople, insertEvent, insertDetail };
+export { fetchEvents, fetchEventDetail, fetchPeople, insertEvent, insertDetail };
 export default {};

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -8,24 +8,32 @@ import TwitterInfo from "../components/TwitterInfo";
 import GoodsInfo from "../components/GoodsInfo";
 import Location from "../components/Location";
 import EventNearHere from "../components/EventsNearHere";
-import { fetchEvents, fetchDetail } from "../apis";
+import { fetchEventDetail } from "../apis";
+import { EventType, DetailType } from "../types";
 
 const Detail = () => {
-	const { id } = useParams();
+  const { id } = useParams();
 
-	const { data: event } = useQuery(["event", id], () => fetchEvents({ infinite: true }), {
-		enabled: !!id,
-		select: (data) => data?.find((item) => item.id === id),
-	});
+  const { data: combinedDetail }: EventType & DetailType | any = useQuery(["detail", id], () => fetchEventDetail({ id }), {
+    enabled: !!id
+  });
 
-	const { data: detail } = useQuery(["detail", id], () => fetchDetail({ id }), {
-		enabled: !!id && !!event,
-	});
-
-	if (!event || !detail) return null;
-
-	const { place, bias, organizer, snsId, startAt, endAt, images, district } = event;
-	const { address, goods, hashTags, tweetUrl } = detail;
+  if (!combinedDetail) return null;
+	console.log(combinedDetail)
+  const {
+    place,
+    bias,
+    organizer,
+    snsId,
+    startAt,
+    endAt,
+    images,
+    district,
+    address,
+    goods,
+    hashTags,
+    tweetUrl
+  } = combinedDetail;
 
 	return (
 		<Layout>


### PR DESCRIPTION
## 구현 내용 
- 상세페이지에서 event 객체 불러지지 않는 버그 수정하였습니다
- api에 `fetchEventDetail` 함수 추가하여 상세페이지 진입 시 
    두 테이블의 정보를 함께 가져오도록 처리하였습니다(`{ ...event, ...detail }`)
  
## 참고 사항 
- api에 몇가지 주석 추가하였습니당
   
## 연관 이슈
