### PR TITLE
feat(27) : 장소 full text search 구현 

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,8 +1,8 @@
 import { ITEMS_PER_PAGE } from "../shared/constants";
 import { supabase } from "../supabaseClient";
-import { EventType, DetailType } from "../types";
+import { EventType, DetailType, FetchEventParams } from "../types";
 
-const fetchEvents = async ({ pageParam = 1, infinite = false }: { pageParam?: number; infinite?: boolean }) => {
+const fetchEvents = async ({ pageParam = 1, infinite = false, keyword }: FetchEventParams) => {
 	let query = supabase.from("events").select("*");
 
 	if (infinite) {
@@ -10,6 +10,11 @@ const fetchEvents = async ({ pageParam = 1, infinite = false }: { pageParam?: nu
 		const startAt = endAt - ITEMS_PER_PAGE === 0 ? endAt - ITEMS_PER_PAGE : endAt - ITEMS_PER_PAGE + 1;
 		query = query.range(startAt, endAt);
 	}
+
+	if (keyword) {
+		query = query.textSearch("place", keyword);
+	}
+
 	const { data } = await query;
 	return data;
 };

--- a/src/components/EventList/index.tsx
+++ b/src/components/EventList/index.tsx
@@ -1,14 +1,22 @@
 import React, { useEffect } from "react";
-import { useInfiniteQuery } from "react-query";
+import { useInfiniteQuery, useQuery } from "react-query";
 import { useInView } from "react-intersection-observer";
+import { useRecoilValue } from "recoil";
 import { StyledList } from "../../styles/eventListStyle";
 import EventListItem from "./EventListItem";
 import { fetchEvents } from "../../apis";
 import { ITEMS_PER_PAGE } from "../../shared/constants";
+import { keywordAtom } from "../../state/atoms";
 
 const EventList = () => {
 	const { ref, inView } = useInView();
-	const { data, hasNextPage, fetchNextPage } = useInfiniteQuery("events", () => fetchEvents({ infinite: true }), {
+	const keyword = useRecoilValue(keywordAtom);
+
+	const {
+		data: events,
+		hasNextPage,
+		fetchNextPage,
+	} = useInfiniteQuery("events", () => fetchEvents({ infinite: true }), {
 		getNextPageParam: (lastPage, pages) => {
 			if (lastPage && lastPage?.length < ITEMS_PER_PAGE) {
 				return null;
@@ -16,6 +24,7 @@ const EventList = () => {
 			return pages.length + 1;
 		},
 	});
+	const { data: searchedEvents } = useQuery(["searchedEvents", keyword], () => fetchEvents({ keyword }));
 
 	useEffect(() => {
 		if (inView && hasNextPage) {
@@ -26,13 +35,14 @@ const EventList = () => {
 	// todo: flat()으로 리팩토링 또는 데이터 구조 변경
 	return (
 		<StyledList>
-			{data?.pages.map((page) =>
-				page?.map((item) => (
-					<div key={item.id} ref={ref}>
-						<EventListItem event={item} key={item.id} />
-					</div>
-				))
-			)}
+			{searchedEvents?.map((event) => <EventListItem event={event} key={event.id} />) ||
+				events?.pages.map((page) =>
+					page?.map((item) => (
+						<div key={item.id} ref={ref}>
+							<EventListItem event={item} key={item.id} />
+						</div>
+					))
+				)}
 		</StyledList>
 	);
 };

--- a/src/components/Filter/SearchInput.tsx
+++ b/src/components/Filter/SearchInput.tsx
@@ -1,18 +1,23 @@
 import React, { useState } from "react";
 import { RiSearchLine } from "react-icons/ri";
+import { useRecoilState } from "recoil";
 import { StyledSearchInput } from "../../styles/filterStyle";
+import { keywordAtom } from "../../state/atoms";
 
 function SearchInput() {
+	const [keyword, setKeyword] = useRecoilState(keywordAtom);
 
-    const [keyword, setKeyword] = useState("")
+	const handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
+		const { value } = e.currentTarget;
+		setKeyword(value);
+	};
 
-    return (
-        <StyledSearchInput>
-            <RiSearchLine />
-            <input value={keyword}
-                onChange={(e) => setKeyword(e.target.value)} />
-        </StyledSearchInput>
-    )
+	return (
+		<StyledSearchInput>
+			<RiSearchLine />
+			<input value={keyword} onChange={handleInputChange} />
+		</StyledSearchInput>
+	);
 }
 
 export default SearchInput;

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -4,15 +4,19 @@ const today = new Date();
 const month: number = today.getMonth() + 1;
 const currentMonthString: string = month < 10 ? `0${month}` : `${month}`;
 
-const monthState = atom({
-  key: "monthState",
-  default: currentMonthString
+export const monthState = atom({
+	key: "monthState",
+	default: currentMonthString,
 });
 
-const biasState = atom({
-  key: "biasState",
-  default: ""
+export const biasState = atom({
+	key: "biasState",
+	default: "",
 });
 
-export { monthState, biasState };
+export const keywordAtom = atom({
+	key: "keywordAtom",
+	default: "",
+});
+
 export default {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,3 +32,9 @@ export type PeopleType = {
 	birthday: string;
 	profilePic: string;
 };
+
+export type FetchEventParams = {
+	pageParam?: number;
+	infinite?: boolean;
+	keyword?: string;
+};


### PR DESCRIPTION
## 구현 내용 
- supabase의 textSearch 메서드를 활용하여 검색창에 장소를 입력할 경우 결과가 렌더링되도록 구현함
  - `민티베리`를 입력하면 카페 민티베리에서 열리는 이벤트가 검색 결과에 노출됩니다. 
  
## 참고 사항 
- textSearch가 full text search에 쓰이는 메서드라 `민티`만 입력하면 검색 실패함... 그리고 `events` 테이블과 `detail` 테이블의 모든 컬럼에서 검색 결과를 가져오려면 결국 postgresql 문법으로 쿼리문을 짜는 방법밖에 없는 것으로 파악하였음 
- 나머지 작업은 시간이 더 걸릴 것 같아서 이슈는 close 하지 않고 구현한 부분만 올립니다~~ 
   
## 연관 이슈
