### PR TITLE
feat(72): updateBiasIds 함수 추가(event.biasId를 people.id와 연동)

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -111,5 +111,35 @@ const insertDetail = async (detailData: Partial<DetailType>) => {
 	return data;
 };
 
-export { fetchEvents, fetchEventDetail, fetchPeople, insertEvent, insertDetail };
+/**
+ * events의 bias ["이름1", "이름2"] 에 맞춰 biasId [13, 4] 입력
+ * 로직 개선 필요
+ */
+const updateBiasIds = async () => {
+  const { data: events } = await supabase.from("events").select("*");
+  const people = await fetchPeople();
+
+  events?.map(async (event) => {
+    const biasId: any[] = [];
+    event.bias.forEach((b: any) => {
+      const peopleObj = people?.find((p) => p.name === b);
+      if (peopleObj) {
+        biasId.push(peopleObj.id);
+      } else {
+				biasId.push(0);
+			}
+    });
+
+    const { data, error } = await supabase
+      .from("events")
+      .update({ biasId })
+      .match({ id: event.id });
+    if (error) {
+      throw new Error(`${error.message}: ${error.details}`);
+    }
+    console.log(data);
+  });
+};
+
+export { fetchEvents, fetchEventDetail, fetchPeople, insertEvent, insertDetail, updateBiasIds };
 export default {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export type EventType = {
 	createdAt: string;
 	place: string;
 	bias: string[];
+	biasId: number[];
 	organizer: string;
 	snsId: string;
 	district: string;


### PR DESCRIPTION
## 구현 내용 
- events의 bias `["이름1", "이름2"]`에 맞춰 biasId `[13, 4]`입력되는 updateBiasIds 함수 추가
- people 테이블에 아직 입력되지 않은 아티스트 이름의 경우 `0`입력되도록 구현함
  
## 참고 사항 
- supabase 상에서는 `["13", "4"]`로 보이나, 실제로 불러왔을 때 `[13, 4]`로 불러와짐!
   
## 연관 이슈
