### PR TITLE
feat(60): 상세페이지 칩 노출 변경, 날짜 표기 변경, 메인 날짜필터 width 수정

### DIFF
--- a/src/components/EventList/EventListItem.tsx
+++ b/src/components/EventList/EventListItem.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { FaUserCircle, FaTwitter, FaMapMarkerAlt, FaCalendar } from "react-icons/fa";
 import { StyledItem } from "../../styles/eventListStyle";
 import { EventType } from "../../types";
+import { convertDateWithDots } from "../../shared/dateHandlers";
 
 type EventListItemProps = {
 	event: EventType;
@@ -37,7 +38,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
 			</p>
 			<p>
 				<FaCalendar />
-				{startAt}-{endAt}
+				{startAt && convertDateWithDots(startAt)} - {endAt && convertDateWithDots(endAt)}
 			</p>
 		</StyledItem>
 	);

--- a/src/components/EventMain/index.tsx
+++ b/src/components/EventMain/index.tsx
@@ -6,6 +6,7 @@ import "slick-carousel/slick/slick-theme.css";
 import { FaUserCircle, FaTwitter, FaMapMarkerAlt, FaCalendar } from "react-icons/fa";
 import { StyledEventMain } from "../../styles";
 import { EventType, DetailType } from "../../types";
+import { convertDateWithDots } from "../../shared/dateHandlers";
 
 type EventMainProps = Partial<EventType> & Partial<DetailType>;
 
@@ -38,7 +39,7 @@ const EventMain = ({ place, bias, organizer, snsId, startAt, endAt, address, ima
         </p>
         <p>
           <FaCalendar />
-          {startAt} - {endAt}
+          {startAt && convertDateWithDots(startAt)} - {endAt && convertDateWithDots(endAt)}
         </p>
       </div>
       <div className="imgContainer">

--- a/src/components/EventMain/index.tsx
+++ b/src/components/EventMain/index.tsx
@@ -16,57 +16,58 @@ const EventMain = ({ place, bias, organizer, snsId, startAt, endAt, address, ima
 		</span>
 	);
 
-	return (
-		<StyledEventMain>
-			<div className="textContainer">
-				<div>
-					<h6>{place}</h6>
-					<span className="biasChip">{bias}</span>
-				</div>
-				<p>
-					<FaUserCircle />
-					{organizer}
-				</p>
-				<p>
-					<FaTwitter />@{snsId}
-				</p>
-
-				<p>
-					<FaMapMarkerAlt />
-					{address}
-				</p>
-				<p>
-					<FaCalendar />
-					{startAt} - {endAt}
-				</p>
-			</div>
-			<div className="imgContainer">
-				{images?.length === 1 ? (
-					/* 이미지 갯수 하나인경우 슬라이드 되지 않음 */
-					<div className="slick-slider">
-						<img alt={images[0]} src={images[0]} />
-						<ul className="slick-dots">
-							<li className="slick-active">
-								<span>1 / 1</span>
-							</li>
-						</ul>
-					</div>
-				) : (
-					<Slider
-						dots
-						infinite
-						slidesToShow={1}
-						slidesToScroll={1}
-						arrows={false}
-						adaptiveHeight={false}
-						customPaging={customPaging}
-					>
-						{images?.length && images?.map((img) => <img alt={img} src={img} key={img} />)}
-					</Slider>
-				)}
-			</div>
-		</StyledEventMain>
-	);
+  return (
+    <StyledEventMain>
+      <div className="textContainer">
+        <div>
+          <h6>{place}</h6>
+          <div className="biasChips">
+            {bias?.map((b) => <span className="biasChip" key={b}>{b}</span>)}
+          </div>
+        </div>
+        <p>
+          <FaUserCircle />
+          {organizer}
+        </p>
+        <p>
+          <FaTwitter />@{snsId}
+        </p>
+        <p>
+          <FaMapMarkerAlt />
+          {address}
+        </p>
+        <p>
+          <FaCalendar />
+          {startAt} - {endAt}
+        </p>
+      </div>
+      <div className="imgContainer">
+        {images?.length === 1 ? (
+          /* 이미지 갯수 하나인경우 슬라이드 되지 않음 */
+          <div className="slick-slider">
+            <img alt={images[0]} src={images[0]} />
+            <ul className="slick-dots">
+              <li className="slick-active">
+                <span>1 / 1</span>
+              </li>
+            </ul>
+          </div>
+        ) : (
+          <Slider
+            dots
+            infinite
+            slidesToShow={1}
+            slidesToScroll={1}
+            arrows={false}
+            adaptiveHeight={false}
+            customPaging={customPaging}
+          >
+            {images?.length && images?.map((img) => <img alt={img} src={img} key={img} />)}
+          </Slider>
+        )}
+      </div>
+    </StyledEventMain>
+  );
 };
 
 export default EventMain;

--- a/src/shared/dateHandlers.ts
+++ b/src/shared/dateHandlers.ts
@@ -53,5 +53,17 @@ const isOpenToday = (today: string, startAt: string, endAt: string) => {
   return false;
 };
 
-export { convertStringToDate, addZero, convertDateToString, isOpenToday };
+/**
+ * YYYY.MM.DD 형식으로 변환
+ * @param {string} dateString YYYYMMDD 형식
+ * @return {string} YYYY.MM.DD 형식
+ */
+const convertDateWithDots = (dateString: string) => {
+  if (dateString.length === 8) {
+    return `${dateString.slice(0, 4)}.${dateString.slice(4, 6)}.${dateString.slice(6, 8)}`;
+  }
+  return dateString;
+};
+
+export { convertStringToDate, addZero, convertDateToString, isOpenToday, convertDateWithDots };
 export default {};

--- a/src/styles/eventMainStyle.ts
+++ b/src/styles/eventMainStyle.ts
@@ -27,15 +27,22 @@ export const StyledEventMain = styled.div`
 				font-weight: 700;
 			}
 
-			> span.biasChip {
-				font-size: 13px;
-				line-height: 17px;
-				font-weight: 700;
-				color: ${({ theme }) => theme.colors.white};
-				background: ${({ theme }) => theme.colors.black};
-				padding: 4px 12px;
-				border-radius: 24px;
-			}
+      > div.biasChips {
+        > span.biasChip {
+          font-size: 13px;
+          line-height: 17px;
+          font-weight: 700;
+          color: ${({ theme }) => theme.colors.white};
+          background: ${({ theme }) => theme.colors.black};
+          padding: 4px 12px;
+          border-radius: 24px;
+        }
+        
+        > span.biasChip:not(:first-child) {
+          margin-left: 4px;
+        }
+      }
+      
 		}
 
 		> p {

--- a/src/styles/layoutStyle.ts
+++ b/src/styles/layoutStyle.ts
@@ -33,7 +33,8 @@ const StyledHeader = styled.header`
 		font-weight: 700;
 
 		> p {
-			margin: 0 10px;
+      width: 150px;
+      text-align: center;
 		}
 
 		> button {


### PR DESCRIPTION
## 구현 내용 
- #60 
  - 상세페이지 칩 노출 여러개 가능하도록 수정
- #61 
  - `dateHandlers.ts`에 `convertDateWithDots`함수 추가(YYYYMMDD -> YYYY.MM.DD 형식으로 변환)
- #71 
  - 날짜 필터 `width: 150px;` 고정

## 참고 사항 
- 작은 스타일 이슈들 한번에 수정하였습니다~
   
## 연관 이슈
