### PR TITLE
feat(98): 가까운 연관 이벤트 가로 전체 너비 차지하도록 수정

### DIFF
--- a/src/components/detail/styles/detailStyle.ts
+++ b/src/components/detail/styles/detailStyle.ts
@@ -1,11 +1,26 @@
 import styled from "styled-components";
 
 const StyledDetail = styled.div`
-	@media ${({ theme }) => theme.device.desktop} {
-		display: flex;
+	display: flex;
+	flex-direction: column;
+	width: 100%;
 
-		> div {
-			width: 50%;
+	> div:first-child {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
+
+		@media ${({ theme }) => theme.device.desktop} {
+			flex-direction: row;
+
+			> div {
+				width: 50%;
+			}
+		}
+
+		.mainInfo,
+		.subInfo {
+			max-width: 540px;
 		}
 	}
 `;

--- a/src/components/detail/styles/eventMainStyle.ts
+++ b/src/components/detail/styles/eventMainStyle.ts
@@ -48,6 +48,7 @@ const StyledEventMain = styled.div`
 	.imgContainer {
 		width: calc(100% - 32px);
 		height: 264px;
+		height: fit-content;
 		position: relative;
 		background: ${({ theme }) => theme.colors.white};
 		box-sizing: content-box !important;

--- a/src/components/detail/styles/eventNearHereStyle.ts
+++ b/src/components/detail/styles/eventNearHereStyle.ts
@@ -2,6 +2,7 @@ import styled from "styled-components";
 
 const StyledEventNearHere = styled.div`
 	padding: 32px 0;
+	width: 100%;
 
 	> h4 {
 		padding: 0 20px;

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -19,29 +19,33 @@ const Detail = () => {
 	);
 
 	if (!combinedDetail) return null;
-	console.log(combinedDetail);
 	const { place, biasesId, organizer, snsId, startAt, endAt, images, district, address, goods, hashTags, tweetUrl } =
 		combinedDetail;
 
+	// TODO: props하나로 묶어서 전달할 수 있도록 리팩토링
 	return (
 		<Layout>
 			<StyledDetail>
-				<EventMain
-					place={place}
-					biasesId={biasesId}
-					organizer={organizer}
-					snsId={snsId}
-					startAt={startAt}
-					endAt={endAt}
-					address={address}
-					images={images}
-				/>
 				<div>
-					<TwitterInfo organizer={organizer} snsId={snsId} hashTags={hashTags} />
-					<GoodsInfo goods={goods} tweetUrl={tweetUrl} />
-					<Location address={address} />
-					<EventNearHere biasesId={biasesId} district={district} />
+					<div className="mainInfo">
+						<EventMain
+							place={place}
+							biasesId={biasesId}
+							organizer={organizer}
+							snsId={snsId}
+							startAt={startAt}
+							endAt={endAt}
+							address={address}
+							images={images}
+						/>
+					</div>
+					<div className="subInfo">
+						<TwitterInfo organizer={organizer} snsId={snsId} hashTags={hashTags} />
+						<GoodsInfo goods={goods} tweetUrl={tweetUrl} />
+						<Location address={address} />
+					</div>
 				</div>
+				<EventNearHere biasesId={biasesId} district={district} />
 			</StyledDetail>
 		</Layout>
 	);


### PR DESCRIPTION
## 구현 내용 
가까운 연관 이벤트 가로 전체 너비 차지하도록 수정
  
## 참고 사항 
- 상세 쪽 건드린 김에 이미지 `height: 100%`으로 수정만 해둠~ 하단 여백 남는 건 bug로 따로 이슈 생성할 예정 
- 데스크탑, 모바일 디자인 제플린으로 1080, 720, 480, 360px 장기적으로는 따로 다 만들어둬야겠단 생각이듦.!! 
- 포스터 세로 길이 `max-width`를 정해야 할 것 같음 
   
## 연관 이슈
close #98
