### PR TITLE
fix(186): 상세 페이지 뒤로가기 아이콘 표시 

### DIFF
--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -12,6 +12,7 @@ type Titles = {
 };
 
 const titles = {
+	detail: "상세보기",
 	request: "이벤트 등록",
 	search: "검색하기",
 } as Titles;
@@ -29,7 +30,7 @@ const Header = ({ page, share }: HeaderProps) => {
 	return (
 		<StyledHeader mainPage={mainPage}>
 			<div id="header">
-				{page === "search" || page === "request" ? (
+				{page !== "main" ? (
 					<Icon name="arrow-left" handleClick={() => navigate(-1)} />
 				) : (
 					<Icon name="logo" handleClick={() => navigate("/")} />


### PR DESCRIPTION
## 구현 내용 
상세 페이지 뒤로가기 아이콘 추가
  
## 참고 사항 
url /main 제외하고는 모두 뒤로가기 아이콘이 발생하도록 설정함(착각했으면 알랴조)
   
## 연관 이슈
close #186 
