### PR TITLE
fix(216): 1.0.0 수정

### DIFF
--- a/src/components/detail/goodsItems/ExtraGoodsListItem.tsx
+++ b/src/components/detail/goodsItems/ExtraGoodsListItem.tsx
@@ -9,11 +9,7 @@ const ExtraGoodsListItem = ({ goodsListItem }: { goodsListItem: { title: string;
 		<StyledGoodsListItem>
 			<h6>{title}</h6>
 			<ul>
-				{items.map((item) => (
-					<li key={item}>
-						<GoodsChip key={item} value={item} />
-					</li>
-				))}
+				{items.map((item) => <GoodsChip key={item} value={item} />)}
 			</ul>
 		</StyledGoodsListItem>
 	);

--- a/src/components/detail/goodsItems/GoodsListItem.tsx
+++ b/src/components/detail/goodsItems/GoodsListItem.tsx
@@ -13,11 +13,7 @@ const GoodsListItem = ({ title, items }: GoodsProps) => (
 	<StyledGoodsListItem>
 		<h6>{TYPE[title]}</h6>
 		<ul>
-			{items.map((item) => (
-				<li key={item}>
-					<GoodsChip key={item} value={item} />
-				</li>
-			))}
+			{items.map((item) => <GoodsChip key={item} value={item} />)}
 		</ul>
 	</StyledGoodsListItem>
 );

--- a/src/components/detail/styles/detailStyle.ts
+++ b/src/components/detail/styles/detailStyle.ts
@@ -4,15 +4,15 @@ const StyledDetail = styled.div`
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	padding: 20px;
 
-	padding-left: 8px;
-	padding-bottom: 0;
+  /** padding .detailInfo 안으로 이동함! */
+  > div.detailInfo {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
 
-	/* > div.detailInfo {
-		display: flex;
-		flex-direction: column;
-		width: 100%; */
+    padding: 20px 20px 0 8px;
+  }
 
 	/* div.mainInfo,
 		div.subInfo {

--- a/src/components/detail/styles/eventNearHereStyle.ts
+++ b/src/components/detail/styles/eventNearHereStyle.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 const StyledEventNearHere = styled.div`
 	margin-top: 40px;
 	width: 100%;
-	padding-left: 12px;
+	padding-left: 20px;
 
 	> h4 {
 		font-weight: 700;

--- a/src/components/detail/styles/eventNearHereStyle.ts
+++ b/src/components/detail/styles/eventNearHereStyle.ts
@@ -3,13 +3,13 @@ import styled from "styled-components";
 const StyledEventNearHere = styled.div`
 	margin-top: 40px;
 	width: 100%;
-	padding-left: 20px;
 
 	> h4 {
 		font-weight: 700;
 		font-size: 20px;
 		line-height: 27px;
 		margin-bottom: 22px;
+    padding-left: 20px;
 	}
 
 	> ul {
@@ -18,12 +18,16 @@ const StyledEventNearHere = styled.div`
 		overflow-y: hidden;
 		-ms-overflow-style: none;
 		scrollbar-width: none;
-		gap: 20px;
 
 		&::-webkit-scrollbar {
 			display: none;
 		}
-
+    
+    &::before {
+      content: "";
+      border-left: 20px solid transparent;
+    }
+    
 		&::after {
 			content: "";
 			border-right: 20px solid transparent;
@@ -34,7 +38,7 @@ const StyledEventNearHere = styled.div`
 const EventNearHereList = styled.li`
 	background: ${({ theme }) => theme.colors.white};
 	border: 2px solid #000000;
-	/* margin-right: 20px; */
+	margin-right: 20px;
 	margin-bottom: 4px;
 	position: relative;
 	box-shadow: 4px 4px 0 #000000;

--- a/src/components/detail/styles/goodsInfoStyle.ts
+++ b/src/components/detail/styles/goodsInfoStyle.ts
@@ -45,33 +45,25 @@ const StyledGoodsListItem = styled.div`
 		margin-bottom: 16px;
 	}
 
-	ul {
-		display: flex;
-		align-items: center;
-		flex-wrap: wrap;
-
-		> li {
-			height: 30px;
-			margin-bottom: 8px;
-			margin-right: 12px;
-		}
+  ul {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    height: fit-content;
+    margin-bottom: 16px;
 	}
 
 	ul.fcfs,
 	ul.lucky {
 		flex-direction: column;
 		align-items: flex-start;
-
-		> li {
-			height: fit-content !important;
-		}
 	}
 `;
 
 const StyledHighLightItem = styled.li`
 	display: flex;
 	align-items: flex-start;
-	margin-top: 12px;
 
 	> .labelContainer {
 		&.length_2 {

--- a/src/components/detail/styles/twitterInfoStyle.ts
+++ b/src/components/detail/styles/twitterInfoStyle.ts
@@ -41,7 +41,7 @@ export const StyledTwitterInfo = styled.div`
 
 	.hashTags {
 		font-weight: 400;
-		font-size: 14px;
+		font-size: 13px;
 		line-height: 18px;
 		flex-wrap: wrap;
 		display: flex;

--- a/src/components/request/styles/requestStyle.ts
+++ b/src/components/request/styles/requestStyle.ts
@@ -48,16 +48,16 @@ const StyledCheckEvent = styled.div`
 `
 
 const StyledEntry = styled.div`
-	width: 50%;
+	//width: 50%;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
 	gap: 30px;
 	padding: 32px 20px;
 
-	@media ${({ theme }) => theme.device.mobile} {
+	//@media ${({ theme }) => theme.device.mobile} {
 		width: 100%;
-	}
+	//}
 
 	.notice {
 		display: flex;
@@ -100,11 +100,11 @@ const StyledEntry = styled.div`
 		gap: 20px;
 		margin-top: 30px;
 
-		@media ${({ theme }) => theme.device.desktop} {
+		/* @media ${({ theme }) => theme.device.desktop} {
 			> button:first-child {
 				display: none;
 			}
-		}
+		} */
 	}
 `;
 
@@ -122,12 +122,24 @@ const StyledPreview = styled.div`
 	flex-direction: column;
 	padding: 14px 0;
 
-	@media ${({ theme }) => theme.device.mobile} {
+	//@media ${({ theme }) => theme.device.mobile} {
 		display: none;
-	}
+	//}
 
 	.previewContent {
 		width: 100%;
+	}
+`;
+
+const StyledRequestBottomSheet = styled.div`
+	width: 100%;
+	padding: 0 20px 32px 12px;
+
+	.previewContent {
+		width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
 	}
 `;
 
@@ -277,5 +289,5 @@ const StyledDuplicatedEvent = styled.div`
 	}
 `;
 
-export { StyledRequest, StyledCheckEvent, StyledEntry, StyledPreview, Label, StyledRequestModal, StyledDuplicatedModal, StyledDuplicatedEvent };
+export { StyledRequest, StyledCheckEvent, StyledEntry, StyledPreview, StyledRequestBottomSheet, Label, StyledRequestModal, StyledDuplicatedModal, StyledDuplicatedEvent };
 export default {};

--- a/src/components/search/Result.tsx
+++ b/src/components/search/Result.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useQuery } from "react-query";
 import { useRecoilState } from "recoil";
 import { StyledResult } from "./styles/resultStyle";
@@ -29,6 +30,8 @@ type ChipType = {
 };
 
 const Result = ({ keyword, biasId }: ResultProps) => {
+	const navigate = useNavigate();
+
 	const [dateRange, setDateRange] = useRecoilState(dateRangeAtom);
 	const { startDate, endDate } = dateRange;
 	const [districts, setDistricts] = useRecoilState(districtAtom);
@@ -127,7 +130,8 @@ const Result = ({ keyword, biasId }: ResultProps) => {
 
 			<div className="request">
 				<p>찾고 있는 이벤트가 없나요?</p>
-				<Button customStyle={{ fontWeight: "bold", width: "178px", height: "50px" }}>이벤트 등록하기</Button>
+				<Button customStyle={{ fontWeight: "bold", width: "178px", height: "50px" }}
+					      handleClick={() => navigate("/request")}>이벤트 등록하기</Button>
 			</div>
 
 			{isModalOpen && (

--- a/src/components/search/styles/eventStyle.ts
+++ b/src/components/search/styles/eventStyle.ts
@@ -70,12 +70,14 @@ export const StyledEvent = styled.div`
 			justify-content: space-around;
 
 			p {
+        display: flex;
+        align-items: center;
 				font-size: 12px;
 				color: ${({ theme }) => theme.colors.gray};
 
 				i,
 				svg {
-					margin-right: 8px;
+					margin-right: 6px;
 				}
 			}
 

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -5,7 +5,7 @@ import { requestGoodsListAtom, requestInputsAtom } from "../state/atoms";
 import Layout from "../shared/components/layout";
 import Entry from "../components/request/Entry";
 import PreviewContent from "../components/request/PreviewContent";
-import { StyledPreview, StyledRequest, StyledCheckEvent } from "../components/request/styles/requestStyle";
+import { StyledPreview, StyledRequest, StyledCheckEvent, StyledRequestBottomSheet } from "../components/request/styles/requestStyle";
 import BottomSheet from "../shared/components/BottomSheet";
 import useMediaQuery from "../hooks/useMediaQuery";
 import { sendReqData } from "../components/request/requestApi";
@@ -33,7 +33,7 @@ const Request = () => {
   const [isSubmitModalOpen, setSubmitModalOpen] = useState(false);
   const [isAlertOpen, setAlertOpen] = useState(false);
   const [isBottomSheetOpen, setBottomSheetOpen] = useState(false);
-  const isMobile = useMediaQuery("(max-width: 720px)");
+  // const isMobile = useMediaQuery("(max-width: 720px)");
 
   const [requestInputs, setRequestInputs] = useRecoilState(requestInputsAtom);
   const [goodsList, setGoodsList] = useRecoilState(requestGoodsListAtom);
@@ -172,7 +172,7 @@ const Request = () => {
 
       {isAlertOpen && <AlertModal setAlertOpen={setAlertOpen} />}
 
-      {isMobile && (
+      {/* {isMobile && ( */}
         <BottomSheet
           open={isBottomSheetOpen}
           setOpen={setBottomSheetOpen}
@@ -184,11 +184,11 @@ const Request = () => {
             handleClick: () => setConfirmModalOpen(true),
           }}
         >
-          <div>
+          <StyledRequestBottomSheet>
             <PreviewContent />
-          </div>
+          </StyledRequestBottomSheet>
         </BottomSheet>
-      )}
+      {/* )} */}
     </>
   );
 };

--- a/src/shared/components/BottomSheet/react-spring-bottom-sheet.css
+++ b/src/shared/components/BottomSheet/react-spring-bottom-sheet.css
@@ -13,7 +13,7 @@
 
   /* custom */
   width: 100%;
-  max-width: 720px;
+  max-width: 480px;
   min-width: 320px;
   padding: 24px 0 16px;
   max-height: calc(100vh - 76px - env(safe-area-inset-top));

--- a/src/shared/components/GoodsChip/goodsChipStyle.ts
+++ b/src/shared/components/GoodsChip/goodsChipStyle.ts
@@ -17,6 +17,7 @@ const StyledGoodsChip = styled.span`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-bottom: 4px;
 `;
 
 

--- a/src/shared/components/Icon/IconStyle.ts
+++ b/src/shared/components/Icon/IconStyle.ts
@@ -10,8 +10,8 @@ export const StyledIcon = styled.i`
 		display: flex;
 		background: url("/images/logo_primary.png") no-repeat;
 		background-size: contain;
-		width: 65px;
-		height: 100%;
+		height: 56px;
+		width: 75px;
 	}
 
 	&.plus-circle {

--- a/src/shared/components/Icon/IconStyle.ts
+++ b/src/shared/components/Icon/IconStyle.ts
@@ -10,8 +10,8 @@ export const StyledIcon = styled.i`
 		display: flex;
 		background: url("/images/logo_primary.png") no-repeat;
 		background-size: contain;
-		height: 56px;
-		width: 75px;
+		height: 42px;
+		width: 56px;
 	}
 
 	&.plus-circle {

--- a/src/shared/components/layout/header/DateSelector.tsx
+++ b/src/shared/components/layout/header/DateSelector.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { useRecoilValue } from "recoil";
 import { dateFilterAtom } from "../../../../state/atoms";
 import { addZero, convertDateToString, convertStringToDate } from "../../../utils/dateHandlers";
-import HeaderCalendar from "./HeaderCalendar";
 import { StyledDateSelector } from "./headerStyle";
 
 type StateProps = {
@@ -25,7 +24,6 @@ function DateSelector({ isCalendarOpen, setCalendarOpen }: StateProps) {
 					<path d="M7.07107 7.14236L14.1421 0.0712891H0L7.07107 7.14236Z" fill="black" />
 				</svg>
 			</button>
-			{isCalendarOpen && <HeaderCalendar setCalendarOpen={setCalendarOpen} />}
 		</StyledDateSelector>
 	);
 }

--- a/src/shared/components/layout/header/headerStyle.ts
+++ b/src/shared/components/layout/header/headerStyle.ts
@@ -84,9 +84,10 @@ export const StyledHeaderCalendarContainer = styled.div`
 
 	width: 100%;
 	min-width: 320px;
-	max-width: 1080px;
+	max-width: 480px;
 	top: ${({ theme }) => theme.heights.header};
-	left: 0;
+	left: 50%;
+  transform: translateX(-50%);
 
 	backdrop-filter: blur(4px);
 

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -66,7 +66,14 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 			<StyledHeader mainPage={mainPage}>
 				<div id="header">
 					{page !== "main" ? (
-						<Icon name="arrow-left" handleClick={handleBackClick || (() => navigate(-1))} />
+						<Icon name="arrow-left"
+									handleClick={handleBackClick ? handleBackClick : () => {
+                    if (window.history.state && window.history.state.idx > 0) {
+                      navigate(-1);
+                    } else {
+                      navigate("/"); // 히스토리가 없으면 메인 페이지로
+                    }
+                  }} />
 					) : (
 						<Icon name="logo" handleClick={handleLogoClick} />
 					)}

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -61,19 +61,21 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 		window.scrollTo({ top: 0 });
 	};
 
+  const goBack = () => {
+    if (window.history.state && window.history.state?.idx > 0) {
+      navigate(-1);
+    } else {
+      navigate("/"); // 이전 히스토리가 없으면 메인 페이지로
+    }
+  }
+
 	return (
 		<>
 			<StyledHeader mainPage={mainPage}>
 				<div id="header">
 					{page !== "main" ? (
 						<Icon name="arrow-left"
-									handleClick={handleBackClick ? handleBackClick : () => {
-                    if (window.history.state && window.history.state.idx > 0) {
-                      navigate(-1);
-                    } else {
-                      navigate("/"); // 히스토리가 없으면 메인 페이지로
-                    }
-                  }} />
+									handleClick={handleBackClick || goBack} />
 					) : (
 						<Icon name="logo" handleClick={handleLogoClick} />
 					)}

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import DateSelector from "./DateSelector";
 import Icon from "../../Icon/Icons";
+import HeaderCalendar from "./HeaderCalendar";
 import { Share, StyledHeader } from "./headerStyle";
 
 type Titles = {
@@ -54,27 +55,30 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 	};
 
 	return (
-		<StyledHeader mainPage={mainPage}>
-			<div id="header">
-				{page !== "main" ? (
-					<Icon name="arrow-left" handleClick={handleBackClick || (() => navigate(-1))} />
-				) : (
-					<Icon name="logo" handleClick={handleLogoClick} />
-				)}
-
-				{page && <h1>{titles[page]}</h1>}
-				<div className="rightIcons">
-					{mainPage && <DateSelector isCalendarOpen={isCalendarOpen} setCalendarOpen={setCalendarOpen} />}
-					{(mainPage || page === "detail") && <Icon name="search_header" handleClick={() => navigate("/search")} />}
-					{share && (
-						<Share>
-							<Icon name="share" handleClick={shareTwitter} />
-							{isTooltipOpen && <span className="tooltip">트위터에 공유하기</span>}
-						</Share>
+		<>
+			<StyledHeader mainPage={mainPage}>
+				<div id="header">
+					{page !== "main" ? (
+						<Icon name="arrow-left" handleClick={handleBackClick || (() => navigate(-1))} />
+					) : (
+						<Icon name="logo" handleClick={handleLogoClick} />
 					)}
+
+					{page && <h1>{titles[page]}</h1>}
+					<div className="rightIcons">
+						{mainPage && <DateSelector isCalendarOpen={isCalendarOpen} setCalendarOpen={setCalendarOpen} />}
+						{(mainPage || page === "detail") && <Icon name="search_header" handleClick={() => navigate("/search")} />}
+						{share && (
+							<Share>
+								<Icon name="share" handleClick={shareTwitter} />
+								<span className="tooltip">트위터에 공유하기</span>
+							</Share>
+						)}
+					</div>
 				</div>
-			</div>
-		</StyledHeader>
+			</StyledHeader>
+			{isCalendarOpen && <HeaderCalendar setCalendarOpen={setCalendarOpen} />}
+		</>
 	);
 };
 

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -34,7 +34,7 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 	const [, setDateFilter] = useRecoilState(dateFilterAtom);
 
 	const [isCalendarOpen, setCalendarOpen] = useState(false);
-	const [, setIsTooltipOpen] = useState(true);
+	const [isTooltipOpen, setIsTooltipOpen] = useState(true);
 	const mainPage = page === "main";
 
 	useEffect(() => {
@@ -78,7 +78,7 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 						{share && (
 							<Share>
 								<Icon name="share" handleClick={shareTwitter} />
-								<span className="tooltip">트위터에 공유하기</span>
+								{isTooltipOpen && <span className="tooltip">트위터에 공유하기</span>}
 							</Share>
 						)}
 					</div>

--- a/src/shared/components/layout/header/index.tsx
+++ b/src/shared/components/layout/header/index.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useRecoilState } from "recoil";
+import { dateFilterAtom } from "../../../../state/atoms";
 import DateSelector from "./DateSelector";
 import Icon from "../../Icon/Icons";
 import HeaderCalendar from "./HeaderCalendar";
 import { Share, StyledHeader } from "./headerStyle";
+import { convertDateToString } from "../../../utils/dateHandlers";
 
 type Titles = {
 	[key: string]: string;
@@ -28,8 +31,10 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 	const navigate = useNavigate();
 	const location = useLocation();
 
+	const [, setDateFilter] = useRecoilState(dateFilterAtom);
+
 	const [isCalendarOpen, setCalendarOpen] = useState(false);
-	const [isTooltipOpen, setIsTooltipOpen] = useState(true);
+	const [, setIsTooltipOpen] = useState(true);
 	const mainPage = page === "main";
 
 	useEffect(() => {
@@ -50,6 +55,8 @@ const Header = ({ page, share, handleBackClick }: HeaderProps) => {
 	};
 
 	const handleLogoClick = () => {
+		const today = new Date();
+		setDateFilter(convertDateToString(today));
 		navigate("/");
 		window.scrollTo({ top: 0 });
 	};

--- a/src/styles/gloabalStyle.ts
+++ b/src/styles/gloabalStyle.ts
@@ -16,6 +16,14 @@ const GlobalStyle = createGlobalStyle<ThemeType>`
     margin: 0;
     background: #fcfbf7;
 
+    // 스크롤바 제거
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    
     div#root {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
## 구현 내용 
- #216 
<img width="528" alt="스크린샷 2022-09-09 오후 9 36 30" src="https://user-images.githubusercontent.com/60878616/189351352-b58c25ed-f9b8-4d3b-a632-146eb52c050c.png">

## 참고 사항 
- 상세페이지 스크롤바 삭제 그냥 전체 다 해둠! (body 태그에) 
  480px제한된 화면에서 신청페이지 바텀시트가 중앙정렬이 안되는 문제 있어서 여기서도 스크롤바가 없어야되게 되어서 전체에서 제거해두었습니당
- 480px을 늦게 merge하면서 헤더가 좀 꼬인듯...!😢 달력 고치면서 다시 돌려뒀어용
   예전으로 돌린 코드에 툴팁 부분만 복사해서 넣어놨는데 혹시 모르니까 확인 부탁드립니당
   
## 연관 이슈
