### PR TITLE
feat(243): 검색 결과에서 상세보기 이동 후 돌아왔을 때 결과 리스트 유지되도록 수정

### DIFF
--- a/src/components/search/Result.tsx
+++ b/src/components/search/Result.tsx
@@ -24,6 +24,8 @@ const sortOptions = {
 	alphabetAsc: "카페: 가나다순",
 };
 
+const initialChipsData = { dateChip: "", distChips: [] };
+
 const Result = ({ biasId, searchParams }: ResultProps) => {
 	const navigate = useNavigate();
 	const [searchFilters, setSearchFilters] = useRecoilState(searchFiltersAtom);
@@ -36,7 +38,7 @@ const Result = ({ biasId, searchParams }: ResultProps) => {
 	const [filterOpen, setFilterOpen] = useState(false);
 	const [calendarOpen, setCalendarOpen] = useState(false);
 	const [districtSelectorOpen, setDistrictSelectorOpen] = useState(false);
-	const [chips, setChips] = useState<{ dateChip: string; distChips: RegCodeItem[] }>({ dateChip: "", distChips: [] });
+	const [chips, setChips] = useState<{ dateChip: string; distChips: RegCodeItem[] }>(initialChipsData);
 
 	const isModalOpen = calendarOpen || districtSelectorOpen;
 	const dateChipText = startDate && `${convertDateWithDots(startDate)} ~ ${convertDateWithDots(endDate)}`;

--- a/src/components/search/SearchInput.tsx
+++ b/src/components/search/SearchInput.tsx
@@ -1,18 +1,21 @@
 import React, { Dispatch, SetStateAction } from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import Icon from "../../shared/components/Icon/Icons";
+import { searchedAtom, searchFiltersAtom } from "../../state";
 import { StyledSearchInput } from "./styles/searchInputStyle";
 
 type SearchInputProps = {
-	keyword: string;
-	setKeyword: Dispatch<SetStateAction<string>>;
-	setSearched: Dispatch<SetStateAction<boolean>>;
 	setSelectedBiasId: Dispatch<SetStateAction<null | number>>;
 };
 
-const SearchInput = ({ keyword, setKeyword, setSearched, setSelectedBiasId }: SearchInputProps) => {
+const SearchInput = ({ setSelectedBiasId }: SearchInputProps) => {
+	const [searchFilters, setSearchFilters] = useRecoilState(searchFiltersAtom);
+	const { keyword } = searchFilters;
+	const setSearched = useSetRecoilState(searchedAtom);
+
 	const handleInputChange = (e: React.FormEvent<HTMLInputElement>) => {
 		const { value } = e.currentTarget;
-		setKeyword(value);
+		setSearchFilters((prev) => ({ ...prev, keyword: value }));
 		setSearched(false);
 	};
 
@@ -24,7 +27,7 @@ const SearchInput = ({ keyword, setKeyword, setSearched, setSelectedBiasId }: Se
 	};
 
 	const handleDeleteClick = () => {
-		setKeyword("");
+		setSearchFilters((prev) => ({ ...prev, keyword: "" }));
 		setSelectedBiasId(null);
 	};
 

--- a/src/components/search/SearchModal.tsx
+++ b/src/components/search/SearchModal.tsx
@@ -6,11 +6,10 @@ import Calendar from "../../shared/components/Calendar";
 import DistrictSelector from "./DistrictSelector";
 import { DateRangeType } from "../../types";
 import { RegCodeItem, SearchModalProps } from "./types";
-import { dateRangeAtom, districtAtom } from "../../state";
+import { searchFiltersAtom } from "../../state";
 
 const SearchModal = ({ type, setCalendarOpen, setDisctrictSelectorOpen }: SearchModalProps) => {
-	const setDateRange = useSetRecoilState(dateRangeAtom);
-	const setDistricts = useSetRecoilState(districtAtom);
+	const setSearchFilters = useSetRecoilState(searchFiltersAtom);
 	const [selectedRange, setSelectedRange] = useState<DateRangeType>({
 		startDate: new Date(),
 		endDate: new Date(),
@@ -27,16 +26,16 @@ const SearchModal = ({ type, setCalendarOpen, setDisctrictSelectorOpen }: Search
 
 		switch (modal) {
 			case "dateRange":
-				setDateRange((prev) => ({
+				setSearchFilters((prev) => ({
 					...prev,
-					startDate: format(startDate, "yyyyMMdd"),
-					endDate: format(endDate, "yyyyMMdd"),
+					date: { startDate: format(startDate, "yyyyMMdd"), endDate: format(endDate, "yyyyMMdd") },
 				}));
+
 				setCalendarOpen(false);
 				break;
 
 			case "district":
-				setDistricts(selectedDists);
+				setSearchFilters((prev) => ({ ...prev, districts: selectedDists }));
 				setDisctrictSelectorOpen(false);
 				break;
 

--- a/src/components/search/types.ts
+++ b/src/components/search/types.ts
@@ -12,9 +12,4 @@ export type RegCodeItem = {
 	selected?: boolean;
 };
 
-export type ChipType = {
-	dateChip: string;
-	distChips: RegCodeItem[];
-};
-
 export default {};

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -52,8 +52,16 @@ const Search = () => {
 	});
 
 	useEffect(() => {
+		setSearchFilters((prev) => ({ ...prev, date: { startDate: "", endDate: "" }, districts: [] }));
+	}, [keyword, setSearchFilters]);
+
+	useEffect(() => {
 		setViewResult(!!(keyword && searched));
-	}, [keyword, searched]);
+
+		if (!keyword) {
+			setSearched(false);
+		}
+	}, [keyword, searched, setSearched]);
 
 	useEffect(() => {
 		if (!viewResult) return;
@@ -61,12 +69,6 @@ const Search = () => {
 			setSearchParams({ keyword });
 		}
 	}, [viewResult, setSearchParams, keyword, setSearchFilters]);
-
-	useEffect(() => {
-		if (!keyword) {
-			setSearched(false);
-		}
-	}, [keyword, setSearched]);
 
 	useEffect(() => {
 		const today = new Date();

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,6 +1,6 @@
 import { atom } from "recoil";
 import { RequestGoodsListType, RequestType } from "../components/request/requestType";
-import { ChipType, RegCodeItem } from "../components/search/types";
+import { RegCodeItem } from "../components/search/types";
 import { convertDateToString } from "../shared/utils/dateHandlers";
 import { sessionAtom } from "./recoilUtils";
 
@@ -19,24 +19,6 @@ export const biasFilterAtom = atom({
 export const openedBiasAtom = atom({
 	key: "openedBiasAtom",
 	default: [] as number[],
-});
-
-export const keywordAtom = atom({
-	key: "keywordAtom",
-	default: "",
-});
-
-export const dateRangeAtom = atom<{ startDate: string; endDate: string }>({
-	key: "dateRangeAtom",
-	default: {
-		startDate: "",
-		endDate: "",
-	},
-});
-
-export const districtAtom = atom<RegCodeItem[]>({
-	key: "districtAtom",
-	default: [],
 });
 
 export const requestInputsAtom = atom<RequestType>({
@@ -68,12 +50,32 @@ export const requestGoodsListAtom = atom<RequestGoodsListType[]>({
 	effects: [sessionAtom],
 });
 
-export const searchFilterChipsAtom = atom<ChipType>({
-	key: "searchFilterChipsAtom",
+export type SearchFiltersAtomType = {
+	keyword: string;
+	date: {
+		startDate: string;
+		endDate: string;
+	};
+	districts: RegCodeItem[];
+};
+
+export const searchFiltersAtom = atom<SearchFiltersAtomType>({
+	key: "searchFilters",
 	default: {
-		dateChip: "",
-		distChips: [],
+		keyword: "",
+		date: {
+			startDate: "",
+			endDate: "",
+		},
+		districts: [],
 	},
+	effects: [sessionAtom],
+});
+
+export const searchedAtom = atom<boolean>({
+	key: "searchedAtom",
+	default: false,
+	effects: [sessionAtom],
 });
 
 export default {};

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,3 +1,4 @@
-import { dateRangeAtom, districtAtom, searchFilterChipsAtom } from "./atoms";
+import { searchFiltersAtom, searchedAtom } from "./atoms";
 
-export { dateRangeAtom, districtAtom, searchFilterChipsAtom };
+export { searchFiltersAtom, searchedAtom };
+export default {};


### PR DESCRIPTION
## 구현 내용 
검색 결과에서 상세보기 이동 후 돌아왔을 때 결과 리스트 유지되도록 수정

## 연관 이슈
close #243 
