### PR TITLE
feat(250): 로딩스피너 추가(메인, 상세페이지), scroll-behavior 수정

### DIFF
--- a/src/components/main/BiasList.tsx
+++ b/src/components/main/BiasList.tsx
@@ -6,13 +6,14 @@ import { fetchPeople } from "../../apis";
 import { dateFilterAtom, openedBiasAtom } from "../../state/atoms";
 import Bias from "./Bias";
 import { StyledBiasList, StyledBias } from "./styles/mainStyle";
+import Loading from "../../shared/components/Loading";
 
 function BiasList() {
 	const navigate = useNavigate();
 	const [openedBias] = useRecoilState(openedBiasAtom);
 	const selectedDate = useRecoilValue(dateFilterAtom);
 
-	const { data: people } = useQuery(["people", selectedDate], () => fetchPeople(), {
+	const { data: people, isLoading } = useQuery(["people", selectedDate], () => fetchPeople(), {
 		select: (data) => {
 			const biasesData = data?.filter((item) => openedBias.includes(item.id)) || [];
 
@@ -27,6 +28,9 @@ function BiasList() {
 		},
 	});
 
+	if (isLoading) {
+		return <Loading />;
+	}
 	return (
 		<StyledBiasList>
 			{people && people?.length ? (

--- a/src/components/main/EventList.tsx
+++ b/src/components/main/EventList.tsx
@@ -7,6 +7,7 @@ import EventListItem from "./EventListItem";
 import { StyledList } from "./styles/mainStyle";
 import EmptyDefault from "./EmptyDefault";
 import GoogleAdvertise, { inFeedAdProps } from "../../shared/components/GoogleAdvertise";
+import Loading from "../../shared/components/Loading";
 
 // todo: useInfiniteQuery 리팩토링 후 추가
 const EventList = () => {
@@ -14,7 +15,7 @@ const EventList = () => {
 	const biasFilter = useRecoilValue(biasFilterAtom);
 	const setOpenedBias = useSetRecoilState(openedBiasAtom);
 
-	const { data: events } = useQuery(["events", dateFilter], () =>
+	const { data: events, isLoading } = useQuery(["events", dateFilter], () =>
 		fetchEvents({
 			date: dateFilter,
 		})
@@ -44,6 +45,9 @@ const EventList = () => {
 		}
 	}, [biasFilter, events]);
 
+	if (isLoading) {
+		return <Loading />;
+	}
 	return (
 		<>
 			<StyledList>

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "react-query";
 import { fetchEventDetail } from "../apis";
@@ -6,13 +6,12 @@ import { EventType, DetailType } from "../types";
 import { StyledDetail } from "../components/detail/styles/detailStyle";
 import { EventMain, EventNearHere, GoodsInfo, TwitterInfo, Location } from "../components/detail";
 import Layout from "../shared/components/layout";
+import Loading from "../shared/components/Loading";
 
 const Detail = () => {
-	window.scrollTo(0, 0);
-
 	const { id } = useParams();
 
-	const { data: combinedDetail }: (EventType & DetailType) | any = useQuery(
+	const { data: combinedDetail, isLoading }: (EventType & DetailType) | any = useQuery(
 		["detail", id],
 		() => fetchEventDetail({ id }),
 		{
@@ -20,7 +19,17 @@ const Detail = () => {
 		}
 	);
 
-	if (!combinedDetail) return null;
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	}, []);
+
+	if (isLoading || !combinedDetail)
+		return (
+			<Layout page="detail">
+				<Loading />
+			</Layout>
+		);
+
 	const { place, biasesId, organizer, snsId, startAt, endAt, images, district, address, goods, hashTags, tweetUrl } =
 		combinedDetail;
 

--- a/src/shared/components/Loading/index.tsx
+++ b/src/shared/components/Loading/index.tsx
@@ -1,0 +1,16 @@
+import React, { memo } from "react";
+import { LoadingSpinnerWrapper, LoadingContainerStyle } from "./loadingStyle";
+
+const Loading = () => (
+  <LoadingContainerStyle>
+    <LoadingSpinnerWrapper>
+      <div />
+      <div />
+      <div />
+      <div />
+    </LoadingSpinnerWrapper>
+  </LoadingContainerStyle>
+);
+
+
+export default memo(Loading);

--- a/src/shared/components/Loading/loadingStyle.ts
+++ b/src/shared/components/Loading/loadingStyle.ts
@@ -39,7 +39,7 @@ export const LoadingSpinnerWrapper = styled.div`
 		border-radius: 50%;
 		animation: ${spinnerKeyframe} 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
 		border: 2px solid;
-		border-color: ${({ theme }) => theme.colors.primary} transparent transparent transparent;
+		border-color: ${({ theme }) => theme.colors.gray} transparent transparent transparent;
 	}
 
 	div:nth-child(1) {

--- a/src/shared/components/Loading/loadingStyle.ts
+++ b/src/shared/components/Loading/loadingStyle.ts
@@ -1,0 +1,58 @@
+import styled, { keyframes } from "styled-components";
+
+export const LoadingContainerStyle = styled.div`
+	display: flex;
+	position: fixed;
+	z-index: ${({ theme }) => theme.zIndex.loadingBackground};
+	top: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 100%;
+	overflow: auto;
+	max-width: ${({ theme }) => theme.widths.layout};
+	height: calc(100vh + ${({ theme }) => theme.heights.header});
+	background: ${({ theme }) => theme.colors.background};
+`;
+
+const spinnerKeyframe = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+export const LoadingSpinnerWrapper = styled.div`
+	display: inline-block;
+	width: 23px;
+	height: 23px;
+	margin: auto;
+	z-index: ${({ theme }) => theme.zIndex.loadingSpinner};
+
+	div {
+		position: absolute;
+		box-sizing: border-box;
+		display: block;
+		width: 23px;
+		height: 23px;
+		border-radius: 50%;
+		animation: ${spinnerKeyframe} 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+		border: 2px solid;
+		border-color: ${({ theme }) => theme.colors.primary} transparent transparent transparent;
+	}
+
+	div:nth-child(1) {
+		animation-delay: -0.45s;
+	}
+
+	div:nth-child(2) {
+		animation-delay: -0.3s;
+	}
+
+	div:nth-child(3) {
+		animation-delay: -0.15s;
+	}
+`;
+
+export default {};

--- a/src/styles/gloabalStyle.ts
+++ b/src/styles/gloabalStyle.ts
@@ -5,6 +5,10 @@ import { ThemeType } from "./theme";
 const GlobalStyle = createGlobalStyle<ThemeType>`
   ${reset};
 
+  html {
+    scroll-behavior: auto;
+  }
+  
   *, *::before, *::after {
     box-sizing: border-box;
     -webkit-tap-highlight-color: transparent;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -31,10 +31,12 @@ const theme: DefaultTheme = {
 	},
 	zIndex: {
 		imageCarousel: 9,
+		loadingBackground: 9,
 		header: 10,
 		bottomSheet: 89, // memo: css 파일에 있어서 직접 입력함
 		modal: 99,
 		toast: 99,
+		loadingSpinner: 999,
 	},
 };
 


### PR DESCRIPTION
## 구현 내용 
- #250 
- 메인, 상세페이지에 로딩스피너 추가함(현재 신청 페이지에는 로딩 필요없어서 안 넣음, 검색에는 필요하면 추가해주세요~!)
- scroll 다 smooth되는 이유가 reset에서 `html{ scroll-behavior: smooth }`를 해놔서 그랬음!!! 없앴어용
   smooth 있는게 더 좋을 것 같은 페이지에는 따로 추가해서 사용하기!
  
## 참고 사항 
   
## 연관 이슈
