### PR TITLE
feat(254): 주소 복사 기능 추가, 가까운 연관 이벤트 명칭 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#IntelliJ project files
+.idea
+.idea/*.xml*
+.idea/*.iml*

--- a/src/components/detail/EventMain.tsx
+++ b/src/components/detail/EventMain.tsx
@@ -8,18 +8,13 @@ import { DEFAULT_POSTER_URL } from "../../shared/constants";
 import { Icon } from "../../shared/components";
 import PosterView from "./PosterView";
 
-type EventMainProps = Partial<EventType> & Partial<DetailType>;
+type EventMainProps = {
+	data: Partial<EventType> & Partial<DetailType>;
+};
 
-const EventMain = ({
-	place,
-	biasesId,
-	organizer,
-	startAt,
-	endAt,
-	address,
-	images,
-	requestedBiases,
-}: EventMainProps) => {
+const EventMain = ({ data }: EventMainProps) => {
+	const { place, biasesId, organizer, startAt, endAt, images, address, requestedBiases } = data;
+
 	const [isPosterViewOpen, setPosterViewOpen] = useState(false);
 
 	const today = convertDateToString(new Date());

--- a/src/components/detail/EventNearHere.tsx
+++ b/src/components/detail/EventNearHere.tsx
@@ -6,7 +6,7 @@ import { EventType } from "../../types";
 import { EventNearHereList, StyledEventNearHere } from "./styles/eventNearHereStyle";
 import { DEFAULT_POSTER_URL } from "../../shared/constants";
 
-function EventNearHere({ biasesId, district }: Partial<EventType>) {
+function EventNearHere({ biasesId, newDistrict }: Partial<EventType>) {
 	const { id } = useParams();
 	const navigate = useNavigate();
 
@@ -15,7 +15,7 @@ function EventNearHere({ biasesId, district }: Partial<EventType>) {
 		select: (data) =>
 			data?.filter((item) => {
 				if (biasesId && biasesId[0]) {
-					return item.id !== id && item.district === district && item.biasesId[0] === biasesId[0];
+					return item.id !== id && item.newDistrict.name === newDistrict?.name && item.biasesId[0] === biasesId[0];
 				}
 				return null;
 			}),
@@ -32,7 +32,7 @@ function EventNearHere({ biasesId, district }: Partial<EventType>) {
 
 	return (
 		<StyledEventNearHere>
-			<h4>가까운 연관 이벤트</h4>
+			<h4>{newDistrict?.name || "가까운"} 연관 이벤트</h4>
 			<ul>
 				{nearEvent &&
 					nearEvent.map((event) => {

--- a/src/components/detail/Location/index.tsx
+++ b/src/components/detail/Location/index.tsx
@@ -1,15 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
+import { FaRegCopy } from "react-icons/fa";
 import { DetailType } from "../../../types";
 import { StyledLocation } from "../styles/locationStyle";
 import Map from "./Map";
+import { copyToClipboard } from "../../../shared/utils/copyHandlers";
+import Toast from "../../../shared/components/Toast";
 
 function Location({ address }: Partial<DetailType>) {
+	const [isToast, setToast] = useState(false);
+
+	const handleClickCopy = () => {
+		if (address) {
+			copyToClipboard(address);
+			setToast(true);
+		}
+	};
+
 	return (
-		<StyledLocation>
-			<h4>위치</h4>
-			<Map address={address} />
-			<p>{address || "카페 주소"}</p>
-		</StyledLocation>
+		<>
+			<StyledLocation>
+				<h4>위치</h4>
+				<Map address={address} />
+				<p>
+					{address || "카페 주소"}
+					<FaRegCopy onClick={handleClickCopy} />
+				</p>
+			</StyledLocation>
+			{isToast && <Toast setToast={setToast} text="주소가 복사되었습니다" />}
+		</>
 	);
 }
 

--- a/src/components/detail/TwitterInfo.tsx
+++ b/src/components/detail/TwitterInfo.tsx
@@ -3,9 +3,12 @@ import { FaTwitter } from "react-icons/fa";
 import { DetailType, EventType } from "../../types";
 import { StyledTwitterInfo } from "./styles/twitterInfoStyle";
 
-type TwitterInfoProps = Partial<EventType> & Partial<DetailType>;
+type TwitterInfoProps = {
+	data: Partial<EventType> & Partial<DetailType>;
+};
 
-function TwitterInfo({ organizer, snsId, hashTags }: TwitterInfoProps) {
+function TwitterInfo({ data }: TwitterInfoProps) {
+	const { organizer, snsId, hashTags } = data;
 	return (
 		<StyledTwitterInfo>
 			<div className="account">

--- a/src/components/detail/styles/locationStyle.ts
+++ b/src/components/detail/styles/locationStyle.ts
@@ -9,10 +9,17 @@ const StyledLocation = styled.div`
 	}
 
 	> p {
+		display: flex;
+		align-items: center;
+		gap: 4px;
 		font-weight: 400;
 		font-size: 14px;
 		line-height: 19px;
 		margin-top: 16px;
+
+		svg {
+			cursor: pointer;
+		}
 	}
 `;
 

--- a/src/components/request/PreviewContent.tsx
+++ b/src/components/request/PreviewContent.tsx
@@ -9,25 +9,31 @@ const PreviewContent = () => {
 	const requestInputs = useRecoilValue(requestInputsAtom);
 	const goodsList = useRecoilValue(requestGoodsListAtom);
 
-	const { place, artist, organizer, snsId, link, posterUrls, hashTags, dateRange, goods } = requestInputs;
+	const { place, artist, organizer, snsId, link, posterUrls, hashTags, dateRange } = requestInputs;
 
 	return (
 		<div className="previewContent">
 			<EventMain
-				place={place.place || "카페이름"}
-				biasesId={[]}
-				requestedBiases={artist[0].bias ? artist : [{ id: 1, peopleId: 0, bias: "아티스트 이름", team: "" }]}
-				organizer={organizer || "주최자 닉네임"}
-				snsId={snsId || "ocup_official"}
-				startAt={dateRange.startAt || "20220000"}
-				endAt={dateRange.endAt || "20220000"}
-				address={place.address || "이벤트 주소"}
-				images={posterUrls[0].publicUrl ? posterUrls.filter((poster) => poster.publicUrl !== "").map((poster) => poster.publicUrl) : [DEFAULT_POSTER_URL]}
+				data={{
+					place: place.place || "카페이름",
+					biasesId: [],
+					requestedBiases: artist[0].bias ? artist : [{ id: 1, peopleId: 0, bias: "아티스트 이름", team: "" }],
+					organizer: organizer || "주최자 닉네임",
+					snsId: snsId || "ocup_official",
+					startAt: dateRange.startAt || "20220000",
+					endAt: dateRange.endAt || "20220000",
+					address: place.address || "이벤트 주소",
+					images: posterUrls[0].publicUrl
+						? posterUrls.filter((poster) => poster.publicUrl !== "").map((poster) => poster.publicUrl)
+						: [DEFAULT_POSTER_URL],
+				}}
 			/>
 			<TwitterInfo
-				organizer={organizer || "주최자 닉네임"}
-				snsId={snsId || "ocup_official"}
-				hashTags={hashTags[0].text ? hashTags.map((h) => h.text) : ["해피_오컵_데이"]}
+				data={{
+					organizer: organizer || "주최자 닉네임",
+					snsId: snsId || "ocup_official",
+					hashTags: hashTags[0].text ? hashTags.map((h) => h.text) : [""],
+				}}
 			/>
 			<GoodsInfo goods={getGoodsObj(requestInputs, goodsList)} tweetUrl={link} />
 			<Location address={place.address} />

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -30,33 +30,22 @@ const Detail = () => {
 			</Layout>
 		);
 
-	const { place, biasesId, organizer, snsId, startAt, endAt, images, district, address, goods, hashTags, tweetUrl } =
-		combinedDetail;
+	const { biasesId, newDistrict, address, goods, tweetUrl } = combinedDetail;
 
-	// TODO: props하나로 묶어서 전달할 수 있도록 리팩토링
 	return (
 		<Layout page="detail" share>
 			<StyledDetail>
 				<div className="detailInfo">
 					<div className="mainInfo">
-						<EventMain
-							place={place}
-							biasesId={biasesId}
-							organizer={organizer}
-							snsId={snsId}
-							startAt={startAt}
-							endAt={endAt}
-							address={address}
-							images={images}
-						/>
+						<EventMain data={combinedDetail} />
 					</div>
 					<div className="subInfo">
-						<TwitterInfo organizer={organizer} snsId={snsId} hashTags={hashTags} />
+						<TwitterInfo data={combinedDetail} />
 						<GoodsInfo goods={goods} tweetUrl={tweetUrl} />
 						<Location address={address} />
 					</div>
 				</div>
-				<EventNearHere biasesId={biasesId} district={district} />
+				<EventNearHere biasesId={biasesId} newDistrict={newDistrict} />
 			</StyledDetail>
 		</Layout>
 	);

--- a/src/shared/components/Toast/toastStyle.ts
+++ b/src/shared/components/Toast/toastStyle.ts
@@ -1,41 +1,41 @@
 import styled from "styled-components";
 
 export const StyledToast = styled.div`
-  display: flex;
-  align-items: center;
-  position: fixed;
-  top: 14px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: ${({ theme }) => theme.zIndex.toast};
-  background: ${({ theme }) => theme.colors.primary};
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
-  width: calc(100% - 40px);
-  max-width: 680px;
-  min-width: 320px;
-  opacity: 0;
-  padding: 14px 20px;
-  animation: snack_animation 3s ease;
-  animation-iteration-count: 1;
+	display: flex;
+	align-items: center;
+	position: fixed;
+	top: 14px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: ${({ theme }) => theme.zIndex.toast};
+	background: ${({ theme }) => theme.colors.primary};
+	box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+	border-radius: 4px;
+	width: calc(100% - 40px);
+	max-width: 440px;
+	min-width: 320px;
+	opacity: 0;
+	padding: 14px 20px;
+	animation: snack_animation 3s ease;
+	animation-iteration-count: 1;
 
-  > p {
-    font-weight: 500;
-    font-size: 12px;
-    line-height: 16px;
-    color: ${({ theme }) => theme.colors.black};
-    white-space: pre;
-  }
+	> p {
+		font-weight: 500;
+		font-size: 12px;
+		line-height: 16px;
+		color: ${({ theme }) => theme.colors.black};
+		white-space: pre;
+	}
 
-  @keyframes snack_animation {
-    0%, 90% {
-      opacity: 1;
-    }
-    100% {
-      opacity: 0;
-    }
-  }
-
+	@keyframes snack_animation {
+		0%,
+		90% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
 `;
 
 export default {};

--- a/src/shared/utils/copyHandlers.ts
+++ b/src/shared/utils/copyHandlers.ts
@@ -1,0 +1,13 @@
+export const copyToClipboard = (copyText: string) => {
+	const el = document.createElement("textarea");
+	el.value = copyText;
+	el.style.opacity = "0";
+	document.body.appendChild(el);
+
+	el.select();
+
+	document.execCommand("copy");
+	document.body.removeChild(el);
+};
+
+export default {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export type EventType = {
 	organizer: string;
 	snsId: string;
 	district: string;
+	newDistrict: { code: string; name: string };
 	startAt: string;
 	endAt: string;
 	images: string[];


### PR DESCRIPTION
## 구현 내용 
- #254 
- #255 
- 지역명은 시/도 단위도 표현되도록 함 (예: `서울 마포구 연관 이벤트`)
  
## 참고 사항 
   
## 연관 이슈
