### PR TITLE
feat(210): 검색 정렬/필터 UI 개선

### DIFF
--- a/src/components/search/Result.tsx
+++ b/src/components/search/Result.tsx
@@ -124,6 +124,7 @@ const Result = ({ biasId }: ResultProps) => {
 						isOpened={sortOpen}
 						setIsOpened={setSortOpen}
 						setSelectedResultOption={setSelectedSortOption}
+						selectedOption={selectedSortOption}
 					/>
 				</div>
 			</div>

--- a/src/components/search/styles/monthSelectorStyle.ts
+++ b/src/components/search/styles/monthSelectorStyle.ts
@@ -64,11 +64,11 @@ export const Month = styled.span<{ isActive: boolean }>`
 	font-weight: bold;
 	text-align: center;
 	border-radius: 4px;
-
 	background-color: ${({ isActive, theme }) => (isActive ? theme.colors.primary : theme.colors.black)};
 	color: ${({ isActive, theme }) => (isActive ? theme.colors.black : theme.colors.white)};
 	border: ${({ isActive }) => (isActive ? "2px solid #000" : "")};
 	line-height: ${({ isActive }) => (isActive ? "28px" : "30px")};
+	cursor: pointer;
 `;
 
 export default {};

--- a/src/components/search/styles/monthSelectorStyle.ts
+++ b/src/components/search/styles/monthSelectorStyle.ts
@@ -31,6 +31,10 @@ export const StyledMonthSelector = styled.div`
 			line-height: 19px;
 			width: fit-content;
 		}
+
+		> svg {
+			cursor: pointer;
+		}
 	}
 
 	.selectBox {

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -128,6 +128,7 @@ const Search = () => {
 						isOpened={searchSortOpen}
 						setIsOpened={setSearchSortOpen}
 						setSelectedSearchOption={setSelectedOption}
+						selectedOption={selectedOption}
 					/>
 				</div>
 

--- a/src/shared/components/FilterIcon/filterIconStyle.ts
+++ b/src/shared/components/FilterIcon/filterIconStyle.ts
@@ -7,7 +7,7 @@ export const StyledFilterIcon = styled.div`
 		position: absolute;
 		width: 120px;
 		height: 104px;
-		box-shadow: ${({ theme }) => theme.style.shadow};
+		box-shadow: ${({ theme }) => theme.style.shadow.default};
 		background-color: ${({ theme }) => theme.colors.background};
 		bottom: -114px;
 		right: 0;

--- a/src/shared/components/SortIcon/index.tsx
+++ b/src/shared/components/SortIcon/index.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from "react";
 import { ResultSortOptionKeys, SearchSortOptionKeys } from "../../../types";
 import Icon from "../Icon/Icons";
-import StyledSortIcon from "./sortIconStyle";
+import { StyledSortIcon, SortOption } from "./sortIconStyle";
 
 type SortProps = {
 	type: "result" | "search";
@@ -9,6 +9,7 @@ type SortProps = {
 	setIsOpened: Dispatch<SetStateAction<boolean>>;
 	setSelectedSearchOption?: Dispatch<SetStateAction<SearchSortOptionKeys>>;
 	setSelectedResultOption?: Dispatch<SetStateAction<ResultSortOptionKeys>>;
+	selectedOption: SearchSortOptionKeys | ResultSortOptionKeys;
 };
 
 const options = {
@@ -24,43 +25,54 @@ const options = {
 	},
 };
 
-const SortIcon = ({ type, isOpened, setIsOpened, setSelectedSearchOption, setSelectedResultOption }: SortProps) => {
+const SortIcon = ({
+	type,
+	isOpened,
+	setIsOpened,
+	setSelectedSearchOption,
+	setSelectedResultOption,
+	selectedOption,
+}: SortProps) => {
 	const renderSortOptions = () => {
 		if (!isOpened) return null;
+
+		// console.log("selectedOption", selectedOption);
 
 		const resultOptionsKeys = Object.keys(options.result) as Array<ResultSortOptionKeys>;
 		const searchOptionKeys = Object.keys(options.search) as Array<SearchSortOptionKeys>;
 
 		switch (type) {
-			case "result":
-				return (
-					<ul>
-						{resultOptionsKeys.map((option) => (
-							<li
-								key={option}
-								role="presentation"
-								onClick={() => setSelectedResultOption && setSelectedResultOption(option)}
-							>
-								{options.result[option]}
-							</li>
-						))}
-					</ul>
-				);
-				break;
 			case "search":
 				return (
 					<ul>
 						{searchOptionKeys.map((option) => (
-							<li
+							<SortOption
 								key={option}
 								role="presentation"
 								onClick={() => setSelectedSearchOption && setSelectedSearchOption(option)}
+								isActive={option === selectedOption}
 							>
 								{options.search[option]}
-							</li>
+							</SortOption>
 						))}
 					</ul>
 				);
+			case "result":
+				return (
+					<ul>
+						{resultOptionsKeys.map((option) => (
+							<SortOption
+								key={option}
+								role="presentation"
+								onClick={() => setSelectedResultOption && setSelectedResultOption(option)}
+								isActive={option === selectedOption}
+							>
+								{options.result[option]}
+							</SortOption>
+						))}
+					</ul>
+				);
+				break;
 			default:
 				return null;
 				break;

--- a/src/shared/components/SortIcon/sortIconStyle.ts
+++ b/src/shared/components/SortIcon/sortIconStyle.ts
@@ -10,20 +10,22 @@ const StyledSortIcon = styled.div`
 		bottom: -130px;
 		right: 0;
 		z-index: 1;
-		box-shadow: ${({ theme }) => theme.style.shadow};
+		box-shadow: ${({ theme }) => theme.style.shadow.default};
 		background-color: ${({ theme }) => theme.colors.background};
-
-		li {
-			height: 42px;
-			font-size: 14px;
-			padding: 10px;
-
-			display: flex;
-			justify-content: flex-end;
-			align-items: center;
-			cursor: pointer;
-		}
 	}
 `;
 
-export default StyledSortIcon;
+const SortOption = styled.li<{ isActive: boolean }>`
+	height: 42px;
+	font-size: 14px;
+	padding: 10px;
+
+	display: flex;
+	justify-content: flex-end;
+	align-items: center;
+	cursor: pointer;
+
+	background-color: ${(props) => (props.isActive ? props.theme.colors.softPrimary : "")};
+`;
+
+export { StyledSortIcon, SortOption };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -7,6 +7,7 @@ const theme: DefaultTheme = {
 	},
 	colors: {
 		primary: "#f9f368",
+		softPrimary: "rgba(249, 243, 104, 0.3)",
 		background: "#fcfbf7",
 		white: "#fff",
 		black: "#000",


### PR DESCRIPTION
## 구현 내용 
- 현재 선택한 옵션 색 표시
- 정렬/필터 박스 default shadow 적용
  
## 참고 사항 
- primary 컬러 opacity 50%적용해서 배경색 지정할 때 더 편하게 쓸 수 있도록 theme에 추가함 `theme.colors.softPrimary`
   
## 연관 이슈
close #210 
