### PR TITLE
feat(268): temp_events로 테이블 이동

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,10 +1,10 @@
 import { ITEMS_PER_PAGE } from "../shared/constants";
 import { isOpenToday } from "../shared/utils/dateHandlers";
 import { supabase } from "../supabaseClient";
-import { EventType, DetailType, FetchEventParams, SearchSortOptionKeys } from "../types";
+import { EventType, FetchEventParams, SearchSortOptionKeys } from "../types";
 
 const fetchEvents = async ({ pageParam = 1, infinite = false, date }: FetchEventParams) => {
-	let query = supabase.from("place_sort").select("*").eq("isApproved", true);
+	let query = supabase.from("temp_place_sort").select("*").eq("isApproved", true);
 
 	if (infinite) {
 		const endAt = pageParam * ITEMS_PER_PAGE;
@@ -33,37 +33,12 @@ const fetchEvents = async ({ pageParam = 1, infinite = false, date }: FetchEvent
  * @param {string} id
  * @returns {EventType}
  */
-const fetchEvent = async ({ id }: { id?: string }) => {
-	const { data, error } = await supabase.from("events").select("*").eq("id", id);
+const fetchEventById = async ({ id }: { id?: string }) => {
+	const { data, error } = await supabase.from("temp_events").select("*").eq("id", id);
 	if (error) {
 		throw new Error(`${error.message}: ${error.details}`);
 	}
 	return data?.[0];
-};
-
-/**
- * 아이디가 일치하는 detail 데이터 반환
- * @param {string} id
- * @returns {DetailType}
- */
-const fetchDetail = async ({ id }: { id?: string }) => {
-	const { data, error } = await supabase.from("detail").select("*").eq("id", id);
-	if (error) {
-		throw new Error(`${error.message}: ${error.details}`);
-	}
-	return data?.[0];
-};
-
-/**
- * 아이디가 일치하는 { ...event, ...detail } 데이터 통합하여 반환
- * @param {string} id
- * @returns {EventType & DetailType}
- */
-const fetchEventDetail = async ({ id }: { id?: string }) => {
-	const event = await fetchEvent({ id });
-	const detail = await fetchDetail({ id });
-
-	return { ...event, ...detail };
 };
 
 /**
@@ -91,21 +66,10 @@ const fetchPeople = async (sortOption?: SearchSortOptionKeys) => {
 };
 
 /**
- * 이벤트 추가
+ * 이벤트 등록 신청
  * */
 const insertEvent = async (eventData: Partial<EventType>) => {
-	const { data, error } = await supabase.from("events").insert([{ ...eventData }]);
-	if (error) {
-		throw new Error(`${error.message}: ${error.details}`);
-	}
-	return data;
-};
-
-/**
- * 디테일 추가
- * */
-const insertDetail = async (detailData: Partial<DetailType>) => {
-	const { data, error } = await supabase.from("detail").insert([{ ...detailData }]);
+	const { data, error } = await supabase.from("temp_events").insert([{ ...eventData }]);
 	if (error) {
 		throw new Error(`${error.message}: ${error.details}`);
 	}
@@ -151,7 +115,7 @@ const fetchDuplicatedEvent = async ({
 	dateRange: { startAt: string; endAt: string };
 }) => {
 	const { data, error } = await supabase
-		.from("events")
+		.from("temp_events")
 		.select("*")
 		.match({ place, startAt: dateRange.startAt, endAt: dateRange.endAt });
 	if (error) {
@@ -160,14 +124,5 @@ const fetchDuplicatedEvent = async ({
 	return data?.[0];
 };
 
-export {
-	fetchEvents,
-	fetchEventDetail,
-	fetchPeople,
-	insertEvent,
-	insertDetail,
-	fetchBiases,
-	uploadPoster,
-	fetchDuplicatedEvent,
-};
+export { fetchEvents, fetchEventById, fetchPeople, insertEvent, fetchBiases, uploadPoster, fetchDuplicatedEvent };
 export default {};

--- a/src/apis/search/index.ts
+++ b/src/apis/search/index.ts
@@ -20,7 +20,7 @@ export type FetchSearchedEventParams = {
 };
 
 const fetchSearchedEvent = async ({ keyword, date, districts, searchInputOptionKey }: FetchSearchedEventParams) => {
-	const { data: allEvents } = await supabase.from("place_sort").select("*").eq("isApproved", true);
+	const { data: allEvents } = await supabase.from("temp_place_sort").select("*").eq("isApproved", true);
 	let data;
 
 	if (!keyword) return data;
@@ -87,7 +87,7 @@ const fetchSearchedEvent = async ({ keyword, date, districts, searchInputOptionK
 		const searchedDist = districts?.[0].code;
 
 		data = data?.filter((event) => {
-			const distCode = event.newDistrict.code.substring(0, 2);
+			const distCode = event.districts.code.substring(0, 2);
 			return searchedDist.includes(distCode);
 		});
 
@@ -97,7 +97,7 @@ const fetchSearchedEvent = async ({ keyword, date, districts, searchInputOptionK
 	const codes = districts.map((dist) => dist.code.substring(0, 4));
 
 	data = data?.filter((event) => {
-		const distCode = event.newDistrict.code.substring(0, 4);
+		const distCode = event.districts.code.substring(0, 4);
 		return codes.includes(distCode);
 	});
 
@@ -105,7 +105,7 @@ const fetchSearchedEvent = async ({ keyword, date, districts, searchInputOptionK
 };
 
 const fetchEventsByBiasId = async (id: number) => {
-	const query = supabase.from("place_sort").select("*").eq("isApproved", true).contains("biasesId", [id]);
+	const query = supabase.from("temp_place_sort").select("*").eq("isApproved", true).contains("biasesId", [id]);
 	const { data } = await query;
 	return data;
 };

--- a/src/components/detail/EventMain.tsx
+++ b/src/components/detail/EventMain.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { EventType, DetailType } from "../../types";
+import { EventType } from "../../types";
 import { convertDateToString, convertDateWithDots, isOpenToday } from "../../shared/utils/dateHandlers";
 import { StyledDetailImgContainer, StyledDetailTextContainer, StyledEventMain } from "./styles/eventMainStyle";
 import { StyledBiasChip } from "../../shared/components/BiasChip/biasChipStyle";
@@ -9,7 +9,7 @@ import PosterView from "./PosterView";
 import { imageOnErrorHandler } from "../../shared/utils/imageHandlers";
 
 type EventMainProps = {
-	data: Partial<EventType> & Partial<DetailType>;
+	data: Partial<EventType>;
 	posterPopupDisabled?: boolean;
 };
 

--- a/src/components/detail/EventNearHere.tsx
+++ b/src/components/detail/EventNearHere.tsx
@@ -6,7 +6,7 @@ import { EventType } from "../../types";
 import { EventNearHereList, StyledEventNearHere } from "./styles/eventNearHereStyle";
 import { imageOnErrorHandler } from "../../shared/utils/imageHandlers";
 
-function EventNearHere({ biasesId, newDistrict }: Partial<EventType>) {
+function EventNearHere({ biasesId, districts }: Partial<EventType>) {
 	const { id } = useParams();
 	const navigate = useNavigate();
 
@@ -15,7 +15,7 @@ function EventNearHere({ biasesId, newDistrict }: Partial<EventType>) {
 		select: (data) =>
 			data?.filter((item) => {
 				if (biasesId && biasesId[0]) {
-					return item.id !== id && item.newDistrict.name === newDistrict?.name && item.biasesId[0] === biasesId[0];
+					return item.id !== id && item.districts.name === districts?.name && item.biasesId[0] === biasesId[0];
 				}
 				return null;
 			}),
@@ -27,7 +27,7 @@ function EventNearHere({ biasesId, newDistrict }: Partial<EventType>) {
 
 	return (
 		<StyledEventNearHere>
-			<p className="title">{newDistrict?.name || "가까운"} 연관 이벤트</p>
+			<p className="title">{districts?.name || "가까운"} 연관 이벤트</p>
 			<ul>
 				{nearEvent &&
 					nearEvent.map((event) => {

--- a/src/components/detail/GoodsInfo.tsx
+++ b/src/components/detail/GoodsInfo.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { DetailType } from "../../types";
+import { EventType } from "../../types";
 import FcfsGoodsListItem from "./goodsItems/FcfsGoodsListItem";
 import GoodsListItem from "./goodsItems/GoodsListItem";
 import ExtraGoodsListItem from "./goodsItems/ExtraGoodsListItem";
 import LuckyGoodsListItem from "./goodsItems/LuckyGoodsListItem";
 import { StyledGoodsInfo } from "./styles/goodsInfoStyle";
 
-function GoodsInfo({ goods, tweetUrl }: Partial<DetailType>) {
+function GoodsInfo({ goods, tweetUrl }: Partial<EventType>) {
 	return (
 		<StyledGoodsInfo>
 			<p className="title">특전</p>

--- a/src/components/detail/Location/Map.tsx
+++ b/src/components/detail/Location/Map.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef } from "react";
-import { DetailType } from "../../../types";
+import { EventType } from "../../../types";
 import { StyledMap } from "../styles/locationStyle";
 import { removeKakaoMapKey, setKakaoMapKey } from "../../../shared/utils/kakaoMapHandlers";
 
-function Map({ address }: Partial<DetailType>) {
+function Map({ address }: Partial<EventType>) {
 	const { kakao } = window as any;
 
 	const container = useRef<HTMLDivElement>(null);

--- a/src/components/detail/Location/index.tsx
+++ b/src/components/detail/Location/index.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
 import { FaRegCopy } from "react-icons/fa";
-import { DetailType } from "../../../types";
+import { EventType } from "../../../types";
 import { StyledLocation } from "../styles/locationStyle";
 import Map from "./Map";
 import { copyToClipboard } from "../../../shared/utils/copyHandlers";
 import Toast from "../../../shared/components/Toast";
 
-function Location({ address }: Partial<DetailType>) {
+function Location({ address }: Partial<EventType>) {
 	const [isToast, setToast] = useState(false);
 
 	const handleClickCopy = () => {

--- a/src/components/detail/TwitterInfo.tsx
+++ b/src/components/detail/TwitterInfo.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { FaTwitter } from "react-icons/fa";
-import { DetailType, EventType } from "../../types";
+import { EventType } from "../../types";
 import { StyledTwitterInfo } from "./styles/twitterInfoStyle";
 
 type TwitterInfoProps = {
-	data: Partial<EventType> & Partial<DetailType>;
+	data: Partial<EventType>;
 };
 
 function TwitterInfo({ data }: TwitterInfoProps) {

--- a/src/components/main/EventListItem.tsx
+++ b/src/components/main/EventListItem.tsx
@@ -16,7 +16,7 @@ type EventListItemProps = {
 
 const EventListItem = ({ event }: EventListItemProps) => {
 	const navigate = useNavigate();
-	const { id, place, images, biasesId, organizer, snsId, newDistrict, startAt, endAt } = event;
+	const { id, place, images, biasesId, organizer, snsId, districts, startAt, endAt } = event;
 
 	return (
 		<StyledItem onClick={() => navigate(`/detail/${id}`)}>
@@ -44,7 +44,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
 				</p>
 				<p>
 					<Icon name="place-gray" />
-					{newDistrict.name}
+					{districts.name}
 				</p>
 				<p>
 					<Icon name="calendar-gray" />

--- a/src/components/main/EventListItem.tsx
+++ b/src/components/main/EventListItem.tsx
@@ -16,7 +16,7 @@ type EventListItemProps = {
 
 const EventListItem = ({ event }: EventListItemProps) => {
 	const navigate = useNavigate();
-	const { id, place, images, biasesId, organizer, snsId, district, startAt, endAt } = event;
+	const { id, place, images, biasesId, organizer, snsId, newDistrict, startAt, endAt } = event;
 
 	return (
 		<StyledItem onClick={() => navigate(`/detail/${id}`)}>
@@ -44,7 +44,7 @@ const EventListItem = ({ event }: EventListItemProps) => {
 				</p>
 				<p>
 					<Icon name="place-gray" />
-					{district}
+					{newDistrict.name}
 				</p>
 				<p>
 					<Icon name="calendar-gray" />

--- a/src/components/main/EventListItem.tsx
+++ b/src/components/main/EventListItem.tsx
@@ -33,24 +33,26 @@ const EventListItem = ({ event }: EventListItemProps) => {
 				<p>{place}</p>
 				<BiasChip id={biasesId[0]} key={biasesId[0]} dots={biasesId.length > 1} />
 			</div>
-			<div className="textContainer">
-				<p>
+			<ul className="textContainer">
+				<li>
 					<Icon name="host-gray" />
-					{organizer}
-				</p>
-				<p>
+					<p>{organizer}</p>
+				</li>
+				<li>
 					<FaTwitter />
-					{snsId ? `@${snsId}` : "-"}
-				</p>
-				<p>
+					<p>{snsId ? `@${snsId}` : "-"}</p>
+				</li>
+				<li>
 					<Icon name="place-gray" />
-					{districts.name}
-				</p>
-				<p>
+					<p>{districts.name}</p>
+				</li>
+				<li>
 					<Icon name="calendar-gray" />
-					{startAt && convertDateWithDots(startAt)} - {endAt && convertDateWithDots(endAt)}
-				</p>
-			</div>
+					<p>
+						{startAt && convertDateWithDots(startAt)} - {endAt && convertDateWithDots(endAt)}
+					</p>
+				</li>
+			</ul>
 		</StyledItem>
 	);
 };

--- a/src/components/main/styles/mainStyle.ts
+++ b/src/components/main/styles/mainStyle.ts
@@ -132,6 +132,14 @@ const StyledItem = styled.li`
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			> span {
+				font-size: 20px;
+				line-height: 50px;
+				font-weight: 700;
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 		}
 	}
 
@@ -140,16 +148,20 @@ const StyledItem = styled.li`
 		flex-direction: column;
 		gap: 4px;
 
-		> p {
+		> li {
+			width: 100%;
 			color: ${({ theme }) => theme.colors.gray};
 			font-size: 14px;
 			line-height: 20px;
 			font-weight: 400;
 			display: flex;
 			align-items: center;
-			white-space: nowrap;
-			overflow: hidden;
-			text-overflow: ellipsis;
+
+			> p {
+				white-space: nowrap;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
 		}
 
 		i,

--- a/src/components/request/Modals/DuplicatedModal.tsx
+++ b/src/components/request/Modals/DuplicatedModal.tsx
@@ -10,7 +10,8 @@ import { EventType } from "../../../types";
 import { convertDateWithDots } from "../../../shared/utils/dateHandlers";
 
 const Event = ({ duplicatedEventData, handleClick }: { duplicatedEventData: EventType; handleClick?: () => void }) => {
-	const { images, place, biasesId, requestedBiases, organizer, snsId, district, startAt, endAt } = duplicatedEventData;
+	const { images, place, biasesId, requestedBiases, organizer, snsId, newDistrict, startAt, endAt } =
+		duplicatedEventData;
 
 	return (
 		<StyledDuplicatedEvent onClick={handleClick}>
@@ -36,7 +37,7 @@ const Event = ({ duplicatedEventData, handleClick }: { duplicatedEventData: Even
 					</p>
 					<p>
 						<FaMapMarkerAlt />
-						{district}
+						{newDistrict.name}
 					</p>
 					<p>
 						<FaCalendar />

--- a/src/components/request/Modals/DuplicatedModal.tsx
+++ b/src/components/request/Modals/DuplicatedModal.tsx
@@ -10,8 +10,7 @@ import { EventType } from "../../../types";
 import { convertDateWithDots } from "../../../shared/utils/dateHandlers";
 
 const Event = ({ duplicatedEventData, handleClick }: { duplicatedEventData: EventType; handleClick?: () => void }) => {
-	const { images, place, biasesId, requestedBiases, organizer, snsId, newDistrict, startAt, endAt } =
-		duplicatedEventData;
+	const { images, place, biasesId, requestedBiases, organizer, snsId, districts, startAt, endAt } = duplicatedEventData;
 
 	return (
 		<StyledDuplicatedEvent onClick={handleClick}>
@@ -37,7 +36,7 @@ const Event = ({ duplicatedEventData, handleClick }: { duplicatedEventData: Even
 					</p>
 					<p>
 						<FaMapMarkerAlt />
-						{newDistrict.name}
+						{districts.name}
 					</p>
 					<p>
 						<FaCalendar />

--- a/src/components/request/Place/PlaceInput.tsx
+++ b/src/components/request/Place/PlaceInput.tsx
@@ -81,7 +81,6 @@ const PlaceInput = () => {
 					...requestInputs,
 					place: {
 						place: placeInfo.place_name,
-						district: `${districtArr[0]} ${districtArr[1]}`,
 						newDistrict: { code: res.data.documents[0].address.b_code, name: `${districtArr[0]} ${districtArr[1]}` },
 						address: placeInfo.road_address_name,
 					},

--- a/src/components/request/Place/PlaceInput.tsx
+++ b/src/components/request/Place/PlaceInput.tsx
@@ -81,7 +81,7 @@ const PlaceInput = () => {
 					...requestInputs,
 					place: {
 						place: placeInfo.place_name,
-						newDistrict: { code: res.data.documents[0].address.b_code, name: `${districtArr[0]} ${districtArr[1]}` },
+						districts: { code: res.data.documents[0].address.b_code, name: `${districtArr[0]} ${districtArr[1]}` },
 						address: placeInfo.road_address_name,
 					},
 				});

--- a/src/components/request/requestApi.ts
+++ b/src/components/request/requestApi.ts
@@ -144,7 +144,6 @@ export const sendReqData = async ({
 		place: place.place,
 		organizer,
 		snsId,
-		district: place.district,
 		newDistrict: place.newDistrict,
 		startAt: dateRange.startAt,
 		endAt: dateRange.endAt,

--- a/src/components/request/requestApi.ts
+++ b/src/components/request/requestApi.ts
@@ -1,5 +1,5 @@
 import React, { Dispatch } from "react";
-import { insertDetail, insertEvent, uploadPoster } from "../../apis";
+import { insertEvent, uploadPoster } from "../../apis";
 import { RequestGoodsListType, RequestType } from "./requestType";
 import { GoodsListType } from "../../types";
 
@@ -142,32 +142,24 @@ export const sendReqData = async ({
 
 	const eventParams = {
 		place: place.place,
+		category: "A", // TODO: 카테고리 수정 필요
 		organizer,
 		snsId,
-		newDistrict: place.newDistrict,
+		districts: place.districts,
+		address: place.address,
+		hashTags: hashTags.map((h) => h.text),
+		goods: getGoodsObj(requestInputs, goodsList),
+		tweetUrl: link,
 		startAt: dateRange.startAt,
 		endAt: dateRange.endAt,
 		images,
 		requestedBiases,
 		isRequested: true,
 		isApproved: false,
-	};
-
-	const detailParams = {
-		// id: 0,
-		address: place.address,
-		hashTags: hashTags.map((h) => h.text),
-		goods: getGoodsObj(requestInputs, goodsList),
-		tweetUrl: link,
+		views: 0,
 	};
 
 	const eventData = await insertEvent(eventParams);
-	if (eventData) {
-		await insertDetail({
-			id: eventData[0].id,
-			...detailParams,
-		});
-	}
 
 	setLoading(false);
 	setConfirmModalOpen(false);

--- a/src/components/request/requestType.ts
+++ b/src/components/request/requestType.ts
@@ -19,7 +19,7 @@ export type RequestArtistType = {
 export type RequestPlaceType = {
 	place: string;
 	address: string;
-	newDistrict: { code: string; name: string };
+	districts: { code: string; name: string };
 };
 
 export type RequestPosterType = {

--- a/src/components/request/requestType.ts
+++ b/src/components/request/requestType.ts
@@ -1,75 +1,74 @@
 export type ItemsType = {
-  id: number;
-  text: string;
-}
+	id: number;
+	text: string;
+};
 
 export type ItemsCountType = {
-  id: number;
-  text: string;
-  count: number;
-}
+	id: number;
+	text: string;
+	count: number;
+};
 
 export type RequestArtistType = {
-  id: number;
-  peopleId: number;
-  bias: string;
-  team: string;
-}
+	id: number;
+	peopleId: number;
+	bias: string;
+	team: string;
+};
 
 export type RequestPlaceType = {
-  place: string;
-  district: string;
-  address: string;
-  newDistrict: { code: string; name: string; }
-}
+	place: string;
+	address: string;
+	newDistrict: { code: string; name: string };
+};
 
 export type RequestPosterType = {
-  id: number;
-  publicUrl: string;
-}
+	id: number;
+	publicUrl: string;
+};
 
 export type RequestDateRangeType = {
-  startAt: string;
-  endAt: string;
-}
+	startAt: string;
+	endAt: string;
+};
 
 export type FcfsDataType = {
-  key?: string;
-  day?: number;
-  items: ItemsCountType[];
-}
+	key?: string;
+	day?: number;
+	items: ItemsCountType[];
+};
 
 export type RequestFcfsType = {
-  type: "A" | "B" | "C";
-  data: FcfsDataType[];
-}
+	type: "A" | "B" | "C";
+	data: FcfsDataType[];
+};
 
 export type RequestGoodsType = {
-  // all?: ItemsType[];
-  // random?: ItemsType[];
-  // dDay?: ItemsType[];
-  firstCome?: RequestFcfsType;
-  lucky?: ItemsCountType[];
-  // extra?: RequestExtraGoodsType[];
-}
+	// all?: ItemsType[];
+	// random?: ItemsType[];
+	// dDay?: ItemsType[];
+	firstCome?: RequestFcfsType;
+	lucky?: ItemsCountType[];
+	// extra?: RequestExtraGoodsType[];
+};
 
 export type RequestGoodsListType = {
-  id: number;
-  title: string;
-  key: string;
-  items: ItemsType[]
-}
+	id: number;
+	title: string;
+	key: string;
+	items: ItemsType[];
+};
 
 export type RequestType = {
-  place: RequestPlaceType;
-  artist: RequestArtistType[];
-  organizer: string;
-  snsId: string;
-  link: string;
-  posterUrls: RequestPosterType[];
-  hashTags: ItemsType[];
-  dateRange: RequestDateRangeType;
-  goods: RequestGoodsType;
-}
+	place: RequestPlaceType;
+	artist: RequestArtistType[];
+	organizer: string;
+	snsId: string;
+	link: string;
+	posterUrls: RequestPosterType[];
+	hashTags: ItemsType[];
+	dateRange: RequestDateRangeType;
+	goods: RequestGoodsType;
+};
 
 export default {};

--- a/src/components/search/Event.tsx
+++ b/src/components/search/Event.tsx
@@ -14,7 +14,7 @@ type EventProps = {
 
 const Event = ({ event }: EventProps) => {
 	const navigate = useNavigate();
-	const { image, place, biasesId, organizer, snsId, district, startAt, endAt, id } = event;
+	const { image, place, biasesId, organizer, snsId, newDistrict, startAt, endAt, id } = event;
 
 	const today = convertDateToString(new Date());
 	const isDuringEvent = isOpenToday(today, startAt!, endAt!);
@@ -45,7 +45,7 @@ const Event = ({ event }: EventProps) => {
 					</li>
 					<li>
 						<Icon name="place-gray" />
-						<p>{district}</p>
+						<p>{newDistrict?.name}</p>
 					</li>
 					<li>
 						<Icon name="calendar-gray" />

--- a/src/components/search/Event.tsx
+++ b/src/components/search/Event.tsx
@@ -14,7 +14,7 @@ type EventProps = {
 
 const Event = ({ event }: EventProps) => {
 	const navigate = useNavigate();
-	const { image, place, biasesId, organizer, snsId, newDistrict, startAt, endAt, id } = event;
+	const { image, place, biasesId, organizer, snsId, districts, startAt, endAt, id } = event;
 
 	const today = convertDateToString(new Date());
 	const isDuringEvent = isOpenToday(today, startAt!, endAt!);
@@ -45,7 +45,7 @@ const Event = ({ event }: EventProps) => {
 					</li>
 					<li>
 						<Icon name="place-gray" />
-						<p>{newDistrict?.name}</p>
+						<p>{districts?.name}</p>
 					</li>
 					<li>
 						<Icon name="calendar-gray" />

--- a/src/pages/Detail.tsx
+++ b/src/pages/Detail.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "react-query";
-import { fetchBiases, fetchEventDetail } from "../apis";
-import { EventType, DetailType } from "../types";
+import { fetchBiases, fetchEventById } from "../apis";
+import { EventType } from "../types";
 import { StyledDetail } from "../components/detail/styles/detailStyle";
 import { EventMain, EventNearHere, GoodsInfo, TwitterInfo, Location } from "../components/detail";
 import Layout from "../shared/components/layout";
@@ -12,57 +12,53 @@ import { setMetaTags } from "../shared/utils/metaTagHandlers";
 const Detail = () => {
 	const { id } = useParams();
 
-	const { data: combinedDetail, isLoading }: (EventType & DetailType) | any = useQuery(
-		["detail", id],
-		() => fetchEventDetail({ id }),
-		{
-			enabled: !!id,
-		}
-	);
+	const { data, isLoading }: EventType | any = useQuery(["detail", id], () => fetchEventById({ id }), {
+		enabled: !!id,
+	});
 
-	const { data: name } = useQuery(["bias", combinedDetail], () => fetchBiases({ id: combinedDetail.biasesId[0] }), {
-		enabled: !!combinedDetail,
+	const { data: name } = useQuery(["bias", data], () => fetchBiases({ id: data.biasesId[0] }), {
+		enabled: !!data,
 	});
 
 	useEffect(() => {
-		if (combinedDetail?.place && name) {
+		if (data?.place && name) {
 			setMetaTags({
 				title: "오늘의 컵홀더 | 상세보기",
-				description: `${combinedDetail.place}에서 열리는 ${name}의 이벤트를 오늘의 컵홀더에서 확인해보세요!`,
+				description: `${data.place}에서 열리는 ${name}의 이벤트를 오늘의 컵홀더에서 확인해보세요!`,
 			});
 		}
 		return () => {
 			setMetaTags({});
 		};
-	}, [combinedDetail, name]);
+	}, [data, name]);
 
 	useEffect(() => {
 		window.scrollTo(0, 0);
 	}, []);
 
-	if (isLoading || !combinedDetail)
+	if (isLoading || !data)
 		return (
 			<Layout page="detail">
 				<Loading />
 			</Layout>
 		);
 
-	const { biasesId, newDistrict, address, goods, tweetUrl } = combinedDetail;
+	const { biasesId, districts, address, goods, tweetUrl } = data;
 
 	return (
 		<Layout page="detail" share>
 			<StyledDetail>
 				<div className="detailInfo">
 					<div className="mainInfo">
-						<EventMain data={combinedDetail} />
+						<EventMain data={data} />
 					</div>
 					<div className="subInfo">
-						<TwitterInfo data={combinedDetail} />
+						<TwitterInfo data={data} />
 						<GoodsInfo goods={goods} tweetUrl={tweetUrl} />
 						<Location address={address} />
 					</div>
 				</div>
-				<EventNearHere biasesId={biasesId} newDistrict={newDistrict} />
+				<EventNearHere biasesId={biasesId} districts={districts} />
 			</StyledDetail>
 		</Layout>
 	);

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -72,7 +72,7 @@ const Request = () => {
 
 	const resetAllStates = () => {
 		setRequestInputs({
-			place: { place: "", address: "", newDistrict: { code: "", name: "" } },
+			place: { place: "", address: "", districts: { code: "", name: "" } },
 			artist: [{ id: 1, peopleId: 0, bias: "", team: "" }],
 			organizer: "",
 			snsId: "",

--- a/src/pages/Request.tsx
+++ b/src/pages/Request.tsx
@@ -72,7 +72,7 @@ const Request = () => {
 
 	const resetAllStates = () => {
 		setRequestInputs({
-			place: { place: "", district: "", address: "", newDistrict: { code: "", name: "" } },
+			place: { place: "", address: "", newDistrict: { code: "", name: "" } },
 			artist: [{ id: 1, peopleId: 0, bias: "", team: "" }],
 			organizer: "",
 			snsId: "",

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -30,7 +30,7 @@ export const tempPostersAtom = atom<{ id: number; file: any; result: string }[]>
 export const requestInputsAtom = atom<RequestType>({
 	key: "requestInputsAtom",
 	default: {
-		place: { place: "", district: "", address: "", newDistrict: { code: "", name: "" } },
+		place: { place: "", address: "", newDistrict: { code: "", name: "" } },
 		artist: [{ id: 1, peopleId: 0, bias: "", team: "" }],
 		organizer: "",
 		snsId: "",

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -30,7 +30,7 @@ export const tempPostersAtom = atom<{ id: number; file: any; result: string }[]>
 export const requestInputsAtom = atom<RequestType>({
 	key: "requestInputsAtom",
 	default: {
-		place: { place: "", address: "", newDistrict: { code: "", name: "" } },
+		place: { place: "", address: "", districts: { code: "", name: "" } },
 		artist: [{ id: 1, peopleId: 0, bias: "", team: "" }],
 		organizer: "",
 		snsId: "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,23 +7,6 @@ export type RequestBias = {
 	team: string;
 };
 
-export type EventType = {
-	id: number;
-	createdAt: string;
-	place: string;
-	bias: string[];
-	biasesId: number[];
-	organizer: string;
-	snsId: string;
-	newDistrict: { code: string; name: string };
-	startAt: string;
-	endAt: string;
-	images: string[];
-	requestedBiases?: RequestBias[];
-	isRequested: boolean;
-	isApproved: boolean;
-};
-
 export type FirstComeDataType = {
 	key?: string;
 	day?: number;
@@ -50,12 +33,26 @@ export type GoodsListType = {
 	extra?: ExtraGoodsType[];
 };
 
-export type DetailType = {
-	id: string;
+export type EventType = {
+	id: number;
+	createdAt: string;
+	place: string;
+	biasesId: number[];
+	organizer: string;
+	snsId: string;
+	districts: { code: string; name: string };
+	startAt: string;
+	endAt: string;
+	images: string[];
 	address: string;
 	goods: GoodsListType;
 	hashTags: string[];
 	tweetUrl: string;
+	category: string;
+	views: number;
+	requestedBiases?: RequestBias[];
+	isRequested: boolean;
+	isApproved: boolean;
 };
 
 export type PeopleType = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,6 @@ export type EventType = {
 	biasesId: number[];
 	organizer: string;
 	snsId: string;
-	district: string;
 	newDistrict: { code: string; name: string };
 	startAt: string;
 	endAt: string;


### PR DESCRIPTION
## 구현 내용 
1. 슈베에 temp_events 테이블 만들기 (이벤트 컬럼+디테일 컬럼, 그리고 newDistrict랑 districts 같이 있음)
1-1. temp_place_sort 뷰 만들기
2. 코드 temp_events, temp_place_sort 바라보도록 수정 (배포된 페이지는 원래 events, detail, place_sort 보고있으니까 오류 없음. 코드에 newDistrict 없도록 수정하기. detail 테이블 엮여있는거 다 수정.)
  
아직 완료되지 않아서 이슈 닫지 않습니다~~


## 참고 사항 
   
## 연관 이슈
