### PR TITLE
feat(336): 줌 상태일때 포스터 스와이프 방지

### DIFF
--- a/components/detail/PosterView.tsx
+++ b/components/detail/PosterView.tsx
@@ -14,6 +14,10 @@ type PosterProps = {
 
 function PosterView({ images, setPosterViewOpen }: PosterProps) {
 	SwiperCore.use([Navigation]);
+
+	const [swiper, setSwiper] = useState<SwiperCore>();
+	const [zoomLevel, setZoomLevel] = useState(1);
+
 	const [pageNum, setPageNum] = useState(1);
 
 	useEffect(() => {
@@ -22,6 +26,24 @@ function PosterView({ images, setPosterViewOpen }: PosterProps) {
 			document.body.style.overflow = "auto";
 		};
 	}, []);
+
+	/** 화면 scale 구하기 */
+	useEffect(() => {
+		function handleResize() {
+			setZoomLevel(window.visualViewport.scale);
+		}
+		window.visualViewport.addEventListener("resize", handleResize);
+		handleResize();
+		return () =>
+			window.visualViewport.removeEventListener("resize", handleResize);
+	}, []);
+
+	/** swiper 스와이프 방지 */
+	useEffect(() => {
+		if (swiper) {
+			swiper.allowTouchMove = zoomLevel <= 1;
+		}
+	}, [zoomLevel, swiper]);
 
 	return (
 		<StyledPosterView>
@@ -38,8 +60,9 @@ function PosterView({ images, setPosterViewOpen }: PosterProps) {
 			</div>
 
 			<Swiper
+				onSwiper={setSwiper}
 				slidesPerView={1}
-				navigation
+				navigation={zoomLevel <= 1}
 				onSlideChange={(e) => setPageNum(e.activeIndex + 1)}
 			>
 				{images.map((img, i) => (


### PR DESCRIPTION
## 구현 내용 
- `feat/next`로 머지합니당
- 화면 배율이 1보다 클 때 포스터 스와이프 되지 않도록 수정함
  
## 참고 사항 
- 추후에 상단 페이지네이션과 X 버튼은 고정되어있고, 사진만 확대될 수 있도록 수정하면 좋을듯..!
   
## 연관 이슈
