### PR TITLE
hotfix: 검색 > 상세 뒤로가기 시 메인으로 돌아가는 문제 수정

### DIFF
--- a/components/detail/index.tsx
+++ b/components/detail/index.tsx
@@ -1,6 +1,9 @@
+import { useRouter } from "next/router";
 import React, { useEffect } from "react";
+import { useRecoilValue } from "recoil";
 import { updateViews } from "../../shared/apis/common";
 import { Layout } from "../../shared/components";
+import { searchFiltersAtom } from "../../shared/state";
 import DetailMainInfo from "./DetailMainInfo";
 import EventNearHere from "./EventNearHere";
 import GoodsInfo from "./GoodsInfo";
@@ -14,6 +17,9 @@ type DetailProps = {
 };
 
 const Detail = ({ data }: DetailProps) => {
+	const router = useRouter();
+	const searchFilters = useRecoilValue(searchFiltersAtom);
+
 	useEffect(() => {
 		window.scrollTo(0, 0);
 	}, []);
@@ -27,8 +33,17 @@ const Detail = ({ data }: DetailProps) => {
 		}
 	}, []);
 
+	const handleBackClick = () => {
+		const { bid, placeName } = searchFilters;
+		if (!bid && !placeName) {
+			router.push("/");
+			return;
+		}
+		router.back();
+	};
+
 	return (
-		<Layout page="detail" share>
+		<Layout page="detail" share handleBackClick={handleBackClick}>
 			<StyledDetail>
 				<div className="detailInfo">
 					<div className="mainInfo">

--- a/shared/components/layout/header/index.tsx
+++ b/shared/components/layout/header/index.tsx
@@ -109,11 +109,7 @@ const Header = ({ page, share, handleBackClick, description }: HeaderProps) => {
 	};
 
 	const goBack = () => {
-		if (window.history.state && window.history.state?.idx > 0) {
-			router.back();
-		} else {
-			router.push("/");
-		}
+		router.back();
 	};
 
 	const renderTooltip = () => {


### PR DESCRIPTION
## 구현 내용 
상세 페이지 링크로 직접 진입 시 뒤로가기 메인으로 이동시키기 위해 `layout/index.tsx`에 작성했던 코드 제거 후 
`detail/index.tsx`에 `handleBackClick`함수를 추가하여 세션 스토리지에 저장된 검색 키워드가 없는 경우 메인으로 돌아가도록 수정함 
(사이드 이펙트로 인해 검색 > 상세 뒤로가기 시 메인으로 돌아가고 있었기 때문~~)   