### PR TITLE
fix(455): 검색 페이지 하단 광고 가운데 정렬

### DIFF
--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -142,7 +142,6 @@ const Search = () => {
 						selectedOption={selectedOption}
 					/>
 				</div>
-
 				<ul className="biases">
 					{people?.map((bias) => (
 						<BiasProfile

--- a/components/search/styles/searchStyle.ts
+++ b/components/search/styles/searchStyle.ts
@@ -48,6 +48,12 @@ export const StyledFilter = styled.div`
 		row-gap: 20px;
 		padding: 12px 0;
 	}
+
+	.aside__kakaoAdFit {
+		display: flex;
+		justify-content: center;
+		margin-top: 20px;
+	}
 `;
 
 export const ResetButton = styled.div`


### PR DESCRIPTION
## 구현 내용 
검색 페이지 하단 광고 가운데 정렬 
  
## 참고 사항 
- 상단에 띠 광고를 추가하니 레이아웃이 깨져서 보류.. 
   
## 연관 이슈
#455 
