### PR TITLE
fix: search 작년 이벤트만 있는 인물 제거

### DIFF
--- a/components/search/hooks/useBiasList.ts
+++ b/components/search/hooks/useBiasList.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "react-query";
+import { fetchPeople } from "../../../shared/apis/common";
+import { getBirthMonth } from "../../../shared/utils";
+import type { PeopleType, SearchSortOptionKeys } from "../../../shared/types";
+
+type Props = {
+	selectedOption: SearchSortOptionKeys;
+	selectedMonth: number | null;
+};
+
+const useBiasList = ({ selectedOption, selectedMonth }: Props) => {
+	const { data: biasList, isLoading } = useQuery(
+		["SEARCH/BIAS_LIST", selectedOption],
+		fetchPeople,
+		{
+			select: (data) => {
+				let biases = data?.filter(
+					(item: PeopleType) => getBirthMonth(item.birthday) === selectedMonth
+				);
+
+				switch (selectedOption) {
+					case "birthdayAsc":
+						biases = biases?.sort(
+							(a, b) => a.birthday.slice(-4) - b.birthday.slice(-4)
+						);
+						break;
+
+					case "birthdayDsc":
+						biases = biases?.sort(
+							(a, b) => b.birthday.slice(-4) - a.birthday.slice(-4)
+						);
+						break;
+
+					case "alphabetAsc":
+					default:
+						break;
+				}
+				return biases;
+			},
+		}
+	);
+
+	return { biasList, isLoading };
+};
+
+export default useBiasList;

--- a/components/search/index.tsx
+++ b/components/search/index.tsx
@@ -1,8 +1,6 @@
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
-import { useQuery } from "react-query";
 import { useRecoilState, useSetRecoilState } from "recoil";
-import { fetchPeople } from "../../shared/apis/common";
 import {
 	BiasProfile,
 	Layout,
@@ -12,10 +10,10 @@ import {
 import KakaoAdFit from "../../shared/components/kakaoAdFit";
 import { initialCategoryData } from "../../shared/constants";
 import { searchFiltersAtom, showResultAtom } from "../../shared/state";
-import { getBirthMonth } from "../../shared/utils";
 import MonthSelector from "./MonthSelector";
 import Result from "./Result";
 import SearchInput from "./SearchInput";
+import useBiasList from "./hooks/useBiasList";
 import useHanleDirectAccess from "./hooks/useHandleDirectAccess";
 import { StyledFilter, StyledSearch } from "./styles/searchStyle";
 import type { SearchSortOptionKeys } from "../../shared/types";
@@ -39,36 +37,10 @@ const Search = () => {
 
 	useHanleDirectAccess();
 
-	const { data: people, isLoading } = useQuery(
-		["people", selectedOption],
-		fetchPeople,
-		{
-			select: (data) => {
-				let biases = data?.filter(
-					(item) => getBirthMonth(item.birthday) === selectedMonth
-				);
-
-				switch (selectedOption) {
-					case "birthdayAsc":
-						biases = biases?.sort(
-							(a, b) => a.birthday.slice(-4) - b.birthday.slice(-4)
-						);
-						break;
-
-					case "birthdayDsc":
-						biases = biases?.sort(
-							(a, b) => b.birthday.slice(-4) - a.birthday.slice(-4)
-						);
-						break;
-
-					case "alphabetAsc":
-					default:
-						break;
-				}
-				return biases;
-			},
-		}
-	);
+	const { biasList, isLoading } = useBiasList({
+		selectedOption,
+		selectedMonth,
+	});
 
 	useEffect(() => {
 		const today = new Date();
@@ -143,7 +115,7 @@ const Search = () => {
 					/>
 				</div>
 				<ul className="biases">
-					{people?.map((bias) => (
+					{biasList?.map((bias: any) => (
 						<BiasProfile
 							key={bias.id}
 							biasName={bias.name}

--- a/shared/components/biasProfile/index.tsx
+++ b/shared/components/biasProfile/index.tsx
@@ -11,14 +11,46 @@ type BiasProfileProps = {
 	id: number;
 };
 
-const BiasProfile = ({ biasName, imgUrl, handleClick, id }: BiasProfileProps) => {
-	const { data } = useQuery(["events", id], () => fetchEventsByBiasId(id));
-	if (!data?.length) return null;
+const BiasProfile = ({
+	biasName,
+	imgUrl,
+	handleClick,
+	id,
+}: BiasProfileProps) => {
+	const { data: availableEvents } = useQuery(
+		["events", id],
+		() => fetchEventsByBiasId(id),
+		{
+			select: (data) => {
+				const thisYear = new Date().getFullYear();
+				const prevYear = thisYear - 1;
+
+				const result = data?.filter((item) => {
+					const eventStartYear = item.startAt.slice(0, 4) * 1;
+					const eventEndYear = item.endAt.slice(0, 4) * 1;
+
+					// NOTE: 12월에 시작해서 1월에 끝나는 이벤트 처리
+					if (eventStartYear !== eventEndYear) {
+						return eventEndYear === thisYear || eventStartYear === prevYear;
+					}
+					return eventEndYear === thisYear;
+				});
+				return result;
+			},
+		}
+	);
+
+	if (!availableEvents?.length) return null;
 
 	return (
 		<StyledBiasProfile onClick={handleClick}>
 			<div>
-				<LazyLoadImage wrapperClassName="lazy-image" alt={biasName} src={imgUrl} effect="blur" />
+				<LazyLoadImage
+					wrapperClassName="lazy-image"
+					alt={biasName}
+					src={imgUrl}
+					effect="blur"
+				/>
 				<p>{biasName}</p>
 			</div>
 		</StyledBiasProfile>


### PR DESCRIPTION
## 구현 내용 

/search 페이지 인물 리스트 중 작년 이벤트만 있는 인물이 노출되어 로직 변경 
- 2~12월 사이의 이벤트는 올해 열린 이벤트만 유효한 것으로 여김
- 12~1월 사이의 이벤트는 작년, 올해 이벤트를 유효한 것으로 여김 
  
## 참고 사항 
   
## 연관 이슈
